### PR TITLE
FFS-3263: replace amazon with amazon flex on popular providers (#929)

### DIFF
--- a/app/app/services/provider_search_service.rb
+++ b/app/app/services/provider_search_service.rb
@@ -140,12 +140,12 @@ class ProviderSearchService
   ]
   TOP_EMPLOYERS = [
     {
-      name: "Amazon",
+      name: "Amazon Flex",
       response_type: "employer",
-      logo_url: "https://cdn.getpinwheel.com/assets/employers/logos/Amazon.svg",
+      logo_url: "https://cdn.getpinwheel.com/assets/employers/logos/Amazon%20Flex.png",
       provider_ids: {
-        pinwheel: "d66e65b2-536d-4b2d-b73c-f6addd66c0f4",
-        argyle: "item_000248659"
+        pinwheel: "eec356b5-9338-4c7c-ac95-b5fdb2213633",
+        argyle: "item_000002104"
       }
     },
     {

--- a/app/app/views/cbv/employer_searches/show.html.erb
+++ b/app/app/views/cbv/employer_searches/show.html.erb
@@ -48,7 +48,7 @@
             data-is-default-option="true"
             data-cbv-employer-search-target="employerButton"
             type="button"
-            class="width-full usa-button usa-button--outline box-shadow-gray"
+            class="width-full height-full usa-button usa-button--outline box-shadow-gray"
           >
             <figure class="margin-0 pointer-events-none">
               <img


### PR DESCRIPTION
(cherry picked from commit 4bd4bc6e718c059a96c651afceff217d836e140b)

## Summary
Pulled in the 'amazon flex' change from DSAC

## Type of Change
Check all that apply.
- [ ] Bug
- [X] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
* pull commit 4bd4bc6e718c059a96c651afceff217d836e140b
* changes name of amazon 'top employer' to 'amazon flex'
* adds a 'height full' class to employer icon

## Checklist
- [ ] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
[if anything need special attention, note it here]
