### PR TITLE
Make VPC CIDRs explicit

### DIFF
--- a/infra/modules/network/main.tf
+++ b/infra/modules/network/main.tf
@@ -1,10 +1,9 @@
 data "aws_availability_zones" "available" {}
 
 locals {
-  vpc_cidr               = "10.0.0.0/20"
-  public_subnet_offset   = 10 # "10.0.10.0"
-  private_subnet_offset  = 0  # "10.0.0.0"
-  database_subnet_offset = 5  # "10.0.5.0"
+  public_subnet_offset   = 10 # e.g. 10.0.0.0/20 -> 10.0.10.0
+  private_subnet_offset  = 0  # e.g. 10.0.0.0/20 -> 10.0.0.0
+  database_subnet_offset = 5  # e.g. 10.0.0.0/20 -> 10.0.5.0
 
   availability_zones = slice(data.aws_availability_zones.available.names, 0, var.num_availability_zones)
 }
@@ -15,20 +14,20 @@ module "aws_vpc" {
 
   name = var.name
   azs  = local.availability_zones
-  cidr = local.vpc_cidr
+  cidr = var.vpc_cidr
 
   # Public subnets
-  public_subnets     = [for i in range(var.num_availability_zones) : cidrsubnet(local.vpc_cidr, 4, local.public_subnet_offset + i)]
+  public_subnets     = [for i in range(var.num_availability_zones) : cidrsubnet(var.vpc_cidr, 4, local.public_subnet_offset + i)]
   public_subnet_tags = { subnet_type = "public" }
 
   # Private subnets
-  private_subnets     = [for i in range(var.num_availability_zones) : cidrsubnet(local.vpc_cidr, 4, local.private_subnet_offset + i)]
+  private_subnets     = [for i in range(var.num_availability_zones) : cidrsubnet(var.vpc_cidr, 4, local.private_subnet_offset + i)]
   private_subnet_tags = { subnet_type = "private" }
 
   # Database subnets
   # `database_subnet_tags` is only used if `database_subnets` is not empty
   # `database_subnet_group_name` is only used if `create_database_subnet_group` is true
-  database_subnets             = [for i in range(var.num_availability_zones) : cidrsubnet(local.vpc_cidr, 4, local.database_subnet_offset + i)]
+  database_subnets             = [for i in range(var.num_availability_zones) : cidrsubnet(var.vpc_cidr, 4, local.database_subnet_offset + i)]
   database_subnet_tags         = { subnet_type = "database" }
   create_database_subnet_group = true
   database_subnet_group_name   = var.database_subnet_group_name

--- a/infra/modules/network/variables.tf
+++ b/infra/modules/network/variables.tf
@@ -1,3 +1,8 @@
+variable "vpc_cidr" {
+  type        = string
+  description = "The IPv4 CIDR block for the VPC"
+}
+
 variable "num_availability_zones" {
   type        = number
   description = "Number of availability zones (AZs) to provision across"

--- a/infra/networks/main.tf
+++ b/infra/networks/main.tf
@@ -75,6 +75,7 @@ module "network" {
   database_subnet_group_name              = local.network_config.database_subnet_group_name
   has_database                            = local.has_database
   has_external_non_aws_service            = local.has_external_non_aws_service
+  vpc_cidr                                = local.network_config.vpc_cidr
   num_availability_zones                  = local.network_config.num_availability_zones
   single_nat_gateway                      = local.network_config.single_nat_gateway
   enable_command_execution                = local.enable_command_execution

--- a/infra/project-config/networks.tf
+++ b/infra/project-config/networks.tf
@@ -25,9 +25,11 @@ locals {
         }
       }
 
+      vpc_cidr               = "10.0.0.0/20"
       num_availability_zones = 3
       single_nat_gateway     = true
     }
+
     prod = {
       account_name               = "prod"
       database_subnet_group_name = "prod"
@@ -44,6 +46,7 @@ locals {
         }
       }
 
+      vpc_cidr               = "10.0.0.0/20"
       num_availability_zones = 3
       single_nat_gateway     = true
     }


### PR DESCRIPTION
This makes the VPC CIDR a required configuration option instead of implicitly using the same CIDR for every single VPC. There are a variety of reasons why reusing CIDRs is bad practice and we should move away from that.

This explicitly sets Demo and Prod to use the existing, same, CIDR, so no actual changes to infra will occur.