### PR TITLE
Fix PA header logo

### DIFF
--- a/app/app/assets/stylesheets/cbv.scss
+++ b/app/app/assets/stylesheets/cbv.scss
@@ -111,6 +111,21 @@ html {
   }
 }
 
+.cbv-header__agency-logo--pa_dhs {
+  max-height: 45px;
+  max-width: 200px;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+
+  @include at-media-max($theme-header-min-width) {
+    height: 30px;
+    width: 200px;
+    min-width: 125px;
+    margin-top: 0.25rem;
+  }
+}
+
 /*
  * Footer
  */

--- a/app/app/assets/stylesheets/cbv.scss
+++ b/app/app/assets/stylesheets/cbv.scss
@@ -113,7 +113,6 @@ html {
 
 .cbv-header__agency-logo--pa_dhs {
   max-height: 45px;
-  max-width: 200px;
   width: auto;
   height: auto;
   object-fit: contain;


### PR DESCRIPTION
## Summary
Fixes an issue where the aspect ratio of the PA logo was off.

This video shows the before/after.  The changes are scoped only to affect PA's logo implementation.

https://github.com/user-attachments/assets/e2a603b8-6153-4f1a-bdb1-d1d4750e707f


## Type of Change
Check all that apply.
- [x] Bug
- [ ] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
[add concise bullet points of changes here]
* Adds `object-fit: contain`: The image keeps its aspect ratio, but is resized to fit within the given dimension 
* Changes from fixed height to max-height to allow it to keep its aspect ratio.
* Set Width and Height to auto so it fits within the bounding box. 

## Checklist
- [ ] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
[if anything need special attention, note it here]
