### PR TITLE
Support creating the DB from a a snapshot

### DIFF
--- a/infra/app/app-config/env-config/database.tf
+++ b/infra/app/app-config/env-config/database.tf
@@ -8,6 +8,8 @@ locals {
     app_access_policy_name      = "${var.app_name}-${var.environment}-app-access"
     migrator_access_policy_name = "${var.app_name}-${var.environment}-migrator-access"
 
+    snapshot_identifier = var.database_snapshot_identifier
+
     serverless_min_capacity = var.database_serverless_min_capacity
     serverless_max_capacity = var.database_serverless_max_capacity
     backup_retention_period = var.backup_retention_period

--- a/infra/app/app-config/env-config/variables.tf
+++ b/infra/app/app-config/env-config/variables.tf
@@ -118,6 +118,12 @@ variable "service_override_extra_environment_variables" {
   default     = {}
 }
 
+variable "database_snapshot_identifier" {
+  description = "Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a DB cluster snapshot, or the ARN when specifying a DB snapshot."
+  default     = null
+  nullable    = true
+}
+
 variable "database_serverless_min_capacity" {
   description = "The minimum capacity for the Aurora Serverless cluster in ACUs (Aurora Capacity Units)"
   type        = number

--- a/infra/app/database/main.tf
+++ b/infra/app/database/main.tf
@@ -93,6 +93,8 @@ module "database" {
   aws_services_security_group_id = data.aws_security_groups.aws_services.ids[0]
   is_temporary                   = local.is_temporary
 
+  snapshot_identifier = local.database_config.snapshot_identifier
+
   serverless_min_capacity = local.database_config.serverless_min_capacity
   serverless_max_capacity = local.database_config.serverless_max_capacity
   backup_retention_period = local.database_config.backup_retention_period

--- a/infra/modules/database/main.tf
+++ b/infra/modules/database/main.tf
@@ -37,6 +37,8 @@ resource "aws_rds_cluster" "db" {
   enable_http_endpoint        = true
   backup_retention_period     = var.backup_retention_period
 
+  snapshot_identifier = var.snapshot_identifier
+
   db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.rds_query_logging.name
 
   # checkov:skip=CKV_AWS_128:Auth decision needs to be ironed out

--- a/infra/modules/database/variables.tf
+++ b/infra/modules/database/variables.tf
@@ -28,6 +28,12 @@ variable "database_name" {
   }
 }
 
+variable "snapshot_identifier" {
+  description = "Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a DB cluster snapshot, or the ARN when specifying a DB snapshot."
+  default     = null
+  nullable    = true
+}
+
 variable "database_subnet_group_name" {
   type        = string
   description = "Name of database subnet group"


### PR DESCRIPTION
Adds support for creating the DB from a snapshot. This is useful for migrating to new environments or aiding in disaster recovery.

## Type of Change
- [ ] Bug
- [X] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
* Adds a new variable that takes a DB snapshot identifier and uses that during DB creation.

## Checklist
- [ ] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
Existing infrastructure is unaffected.