### PR TITLE
fix issue where client agency configuration was not loading sftp_filename

### DIFF
--- a/app/app/services/client_agency/select_client_agency_configuration_class.rb
+++ b/app/app/services/client_agency/select_client_agency_configuration_class.rb
@@ -1,0 +1,5 @@
+module ClientAgency::SelectClientAgencyConfigurationClass
+  def self.for(client_agency_id)
+    "ClientAgency::#{client_agency_id.camelize}::Configuration".safe_constantize
+  end
+end

--- a/app/app/services/transmitters/sftp_transmitter.rb
+++ b/app/app/services/transmitters/sftp_transmitter.rb
@@ -4,7 +4,8 @@ class Transmitters::SftpTransmitter
   def deliver
     config = current_agency.transmission_method_configuration.with_indifferent_access
     sftp_gateway = SftpGateway.new(config)
-    filename = current_agency.pdf_filename(cbv_flow, cbv_flow.consented_to_authorized_use_at)
+    filename = ClientAgency::SelectClientAgencyConfigurationClass.for(cbv_flow.client_agency_id)
+                   .pdf_filename(cbv_flow, cbv_flow.consented_to_authorized_use_at)
     sftp_gateway.upload_data(StringIO.new(pdf_output.content), "#{config["sftp_directory"]}/#{filename}.pdf")
   end
 


### PR DESCRIPTION

## Summary
[type a brief description here]
fix issue where client agency configuration was not loading sftp_filename

## Type of Change
Check all that apply.
- [x] Bug
- [ ] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
[add concise bullet points of changes here]
* Add new configuration helper class to grab the right configuration class for a client_agency_id
* Change the pdf_filename call to call this configured class

## Checklist
- [x] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
[if anything need special attention, note it here]
