### PR TITLE
hotfix for sftp pdf name, back to main

### DIFF
--- a/app/app/services/client_agency/sandbox/configuration.rb
+++ b/app/app/services/client_agency/sandbox/configuration.rb
@@ -1,0 +1,35 @@
+# TODO: clean this up for sandbox, since it was a direct copy of pa_dhs.
+class ClientAgency::Sandbox::Configuration
+  def self.sftp_transmission_configuration
+    Rails.application.config.client_agencies["sandbox"]
+      .transmission_method_configuration
+      .with_indifferent_access
+  end
+
+  def self.client_agency_id
+    "sandbox"
+  end
+
+  def self.pdf_filename(cbv_flow, time)
+    time = time.in_time_zone("America/New_York")
+    "CBVPilot_#{case_number(cbv_flow)}_" \
+      "#{time.strftime('%Y%m%d')}_" \
+      "Conf#{cbv_flow.confirmation_code}"
+  end
+
+  def self.case_number(cbv_flow)
+    cbv_flow.cbv_applicant.case_number.rjust(8, "0")
+  end
+
+  def self.format_timezone(time)
+    return nil if time.nil?
+
+    time.in_time_zone("America/New_York").strftime("%m/%d/%Y %H:%M:%S")
+  end
+
+  def self.format_date(time)
+    return nil if time.nil?
+
+    time.in_time_zone("America/New_York").strftime("%m/%d/%Y")
+  end
+end

--- a/app/app/services/client_agency/select_client_agency_configuration_class.rb
+++ b/app/app/services/client_agency/select_client_agency_configuration_class.rb
@@ -1,0 +1,5 @@
+module ClientAgency::SelectClientAgencyConfigurationClass
+  def self.for(client_agency_id)
+    "ClientAgency::#{client_agency_id.camelize}::Configuration".safe_constantize
+  end
+end

--- a/app/app/services/transmitters/sftp_transmitter.rb
+++ b/app/app/services/transmitters/sftp_transmitter.rb
@@ -4,7 +4,8 @@ class Transmitters::SftpTransmitter
   def deliver
     config = current_agency.transmission_method_configuration.with_indifferent_access
     sftp_gateway = SftpGateway.new(config)
-    filename = current_agency.pdf_filename(cbv_flow, cbv_flow.consented_to_authorized_use_at)
+    filename = ClientAgency::SelectClientAgencyConfigurationClass.for(cbv_flow.client_agency_id)
+                   .pdf_filename(cbv_flow, cbv_flow.consented_to_authorized_use_at)
     sftp_gateway.upload_data(StringIO.new(pdf_output.content), "#{config["sftp_directory"]}/#{filename}.pdf")
   end
 


### PR DESCRIPTION
…name (#136)

* fix issue where client agency configuration was not loading in sftp.  created new helper method to choose the correct Configuration.rb file.

* fixed a semi-related test that was breaking because it was trying to grab sftp information for sandbox agency which does not have configuration.rb

* fixed a semi-related test that was breaking because it was trying to grab sftp information for sandbox agency which does not have configuration.rb

* amend commit
