### PR TITLE
update rspec

### DIFF
--- a/app/app/views/cbv/employer_searches/_employer.html.erb
+++ b/app/app/views/cbv/employer_searches/_employer.html.erb
@@ -57,7 +57,7 @@
         <%= t("cbv.employer_searches.show.to_continue_li_1") %>
         <%= t("cbv.employer_searches.show.to_continue_li_1_html",
           agency_contact_website: current_agency.agency_contact_website,
-          agency_acronym: agency_translation("shared.agency_acronym")
+          agency_portal_name: agency_translation("shared.agency_portal_name")
         ) %>
       </li>
       <li><%= t("cbv.employer_searches.show.to_continue_li_2") %></li>
@@ -71,7 +71,7 @@
     <% if @has_payroll_account %>
       <%= link_to t("cbv.employer_searches.show.review_button_text"), cbv_flow_applicant_information_path, class: "usa-button usa-button--outline margin-top-5", data: { turbo_frame: "_top" } %>
     <% else %>
-      <%= link_to t("cbv.employer_searches.show.exit_button_text", agency_acronym: agency_translation("shared.agency_acronym")), current_agency.agency_contact_website, class: "usa-button usa-button--outline margin-top-5",  target: :_blank, rel: "noopener noreferrer", data: { turbo_frame: "_top" } %>
+      <%= link_to t("cbv.employer_searches.show.exit_button_text", agency_portal_name: agency_translation("shared.agency_portal_name")), current_agency.agency_contact_website, class: "usa-button usa-button--outline margin-top-5",  target: :_blank, rel: "noopener noreferrer", data: { turbo_frame: "_top" } %>
     <% end %>
 
     <hr class="margin-y-5 border-base-light border-top-0" >

--- a/app/app/views/cbv/entries/show.html.erb
+++ b/app/app/views/cbv/entries/show.html.erb
@@ -3,7 +3,7 @@
 <div data-controller="cbv-entry-page">
   <h1><%= title %></h1>
 
-  <p><%= t(".subheader_html", agency_acronym: agency_translation("shared.agency_acronym")) %></p>
+  <p><%= t(".subheader_html", agency_full_name: agency_translation("shared.agency_full_name")) %></p>
 
   <ol class="usa-process-list">
     <li class="usa-process-list__item">
@@ -41,8 +41,8 @@
       <%= t(".what_if_i_cant_use_this_title") %>
     <% end %>
     <% accordion.with_accordion_item do %>
-      <%= t(".what_if_i_cant_use_this_body_1", agency_acronym: agency_translation("shared.agency_acronym")) %>
-      <%= agency_translation(".what_if_i_cant_use_this_body_2_html", agency_url: current_agency.agency_contact_website, agency_acronym: agency_translation("shared.agency_acronym")) %>
+      <%= t(".what_if_i_cant_use_this_body_1", agency_portal_name: agency_translation("shared.agency_portal_name")) %>
+      <%= agency_translation(".what_if_i_cant_use_this_body_2_html", agency_url: current_agency.agency_contact_website, agency_portal_name: agency_translation("shared.agency_portal_name")) %>
     <% end %>
   <% end %>
 </div>

--- a/app/app/views/cbv/expired_invitations/show.html.erb
+++ b/app/app/views/cbv/expired_invitations/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, t(".title") %>
 
 <h1><%= t(".title") %></h1>
-<p><%= t(".body_1", agency_acronym: agency_translation("shared.agency_acronym")) %></p>
+<p><%= agency_translation(".body_1_html", agency_url: current_agency.agency_contact_website, agency_portal_name: agency_translation("shared.agency_portal_name")) %></p>
 
 <div class="margin-top-3">
   <%= agency_translation(".cta_button_html", agency_url: agency_url) %>

--- a/app/app/views/cbv/missing_results/show.html.erb
+++ b/app/app/views/cbv/missing_results/show.html.erb
@@ -3,12 +3,12 @@
 <h1><%= t(".header") %></h1>
 <p><%= t(".not_listed_p1", agency_acronym: agency_translation("shared.agency_acronym")) %></p>
 <% if @has_payroll_account %>
-  <p><%= t(".not_listed_p2_link_html", agency_url: agency_url, agency_acronym: agency_translation("shared.agency_acronym")) %></p>
+  <p><%= t(".not_listed_p2_link_html", agency_url: agency_url, agency_portal_name: agency_translation("shared.agency_portal_name")) %></p>
 <% else %>
-  <p><%= t(".not_listed_p2", agency_acronym: agency_translation("shared.agency_acronym")) %></p>
+  <p><%= t(".not_listed_p2", agency_portal_name: agency_translation("shared.agency_portal_name")) %></p>
   <%= t(".exit_button_html",
     agency_contact_website: current_agency.agency_contact_website,
-    agency_full_name: agency_translation("shared.agency_full_name")
+    agency_portal_name: agency_translation("shared.agency_portal_name")
   ) %>
 <% end %>
 

--- a/app/app/views/cbv/other_jobs/show.html.erb
+++ b/app/app/views/cbv/other_jobs/show.html.erb
@@ -13,7 +13,7 @@
   <%= f.radio_button(:has_other_jobs, true, { label: t(".radio_yes") }) %>
   <%= f.radio_button(:has_other_jobs, false, { label: t(".radio_no") }) %>
 
-  <p><%= t(".note_html", agency_site: current_agency.agency_contact_website, agency_acronym: agency_translation("shared.agency_acronym")) %></p>
+  <p><%= t(".note_html", agency_site: current_agency.agency_contact_website, agency_portal_name: agency_translation("shared.agency_portal_name")) %></p>
 
   <%= f.submit t("continue") %>
 <% end %>

--- a/app/app/views/cbv/successes/show.html.erb
+++ b/app/app/views/cbv/successes/show.html.erb
@@ -30,7 +30,7 @@
         <div class="usa-icon-list__content">
           <h3 class="margin-bottom-1"><%= t(".whats_next_1_title") %></h3>
           <p><%= t(".whats_next_1_li_1", agency_acronym: agency_translation("shared.agency_acronym")) %></p>
-          <p><%= t(".whats_next_1_li_2_html", agency_acronym: agency_translation("shared.agency_acronym"), agency_website: current_agency.agency_contact_website) %></p>
+          <p><%= t(".whats_next_1_li_2_html", agency_portal_name: agency_translation("shared.agency_portal_name"), agency_website: current_agency.agency_contact_website) %></p>
         </div>
       </li>
       <li class="usa-icon-list__item">

--- a/app/app/views/cbv/summaries/show.html.erb
+++ b/app/app/views/cbv/summaries/show.html.erb
@@ -36,7 +36,7 @@
 <!-- Generic link flow, no invitation -->
 <% if @cbv_flow.cbv_flow_invitation.blank? %>
 <h2><%= t(".your_information") %></h2>
-<p><%= agency_translation(".must_match", agency_acronym: agency_translation("shared.agency_acronym")) %></p>
+<p><%= agency_translation(".must_match", agency_portal_name: agency_translation("shared.agency_portal_name")) %></p>
 <div class="display-flex flex-justify font-body-md">
   <h3><%= t(".application_information") %></h3>
   <%= link_to t(".edit"), cbv_flow_applicant_information_path(force_show: true), class: "usa-link text-bold margin-0" %>

--- a/app/app/views/cbv/synchronization_failures/show.html.erb
+++ b/app/app/views/cbv/synchronization_failures/show.html.erb
@@ -7,7 +7,7 @@
 <ol>
   <li><%= t(".option_1") %></li>
   <li><%= t(".option_2") %></li>
-  <li><%= t(".option_3", agency_acronym: agency_translation("shared.agency_acronym")) %></li>
+  <li><%= t(".option_3", agency_portal_name: agency_translation("shared.agency_portal_name")) %></li>
   <% if @cbv_flow.has_account_with_required_data? %>
     <li><%= t("cbv.missing_results.show.continue_to_review", agency_acronym: agency_translation("shared.agency_acronym")) %></li>
   <% end %>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -253,7 +253,7 @@ en:
         app_based_providers: App-based employers
         can_not_find_employer: I can’t find my employer or payroll provider
         employer_not_listed: Employer not listed?
-        exit_button_text: Exit and go to %{agency_acronym}'s website
+        exit_button_text: Exit and go to the %{agency_portal_name} website
         header: Search for your employer or payroll provider
         no_results_steps1: Check if your employer uses another business name or search for their payroll provider.
         no_results_steps2: Make sure you have spelled names correctly, then search again.
@@ -269,7 +269,7 @@ en:
         select: Select
         to_continue: 'If you still don’t see your employer or payroll provider listed:'
         to_continue_li_1: You’ll need to submit that income information separately.
-        to_continue_li_1_html: <a href="%{agency_contact_website}" target="_blank" rel="noopener noreferrer">Go to %{agency_acronym}'s website</a> to learn about other ways to report your income.
+        to_continue_li_1_html: <a href="%{agency_contact_website}" target="_blank" rel="noopener noreferrer">Go to the %{agency_portal_name} website</a> to learn about other ways to report your income.
         to_continue_li_2: If you have other jobs to add, search for them.
         to_continue_li_3: If you have no other jobs to add here, you can exit this site.
         to_continue_li_3_continue: If you have no other jobs to add here, continue to review your income report.
@@ -288,10 +288,10 @@ en:
         step2_description: You will be able to preview and approve everything that is shared with %{agency_acronym}.
         step3: Submit your payment information.
         step3_description: We’ll automatically send it to %{agency_acronym}. This will help you prove your income and can help %{agency_acronym} get to a decision faster.
-        subheader_html: 'We’ll send your payment records from your employer(s) to %{agency_acronym} to verify your income. <strong>Most people complete this process in about 5 minutes.</strong> Just follow these steps:'
-        what_if_i_cant_use_this_body_1: If you need to report your income and can’t use this tool, then you’ll need to share your income information for this job directly with %{agency_acronym}.
+        subheader_html: 'We’ll send your payment records from your employer(s) to %{agency_full_name} to verify your income. <strong>Most people complete this process in about 5 minutes.</strong> Just follow these steps:'
+        what_if_i_cant_use_this_body_1: If you need to report your income and can’t use this tool, then you’ll need to share your income information for this job directly with %{agency_portal_name}.
         what_if_i_cant_use_this_body_2_html:
-          default: Visit <a href="%{agency_url}" target="_blank" rel="noopener noreferrer">%{agency_acronym}’s website</a> for more information on how to submit documents.
+          default: Visit the <a href="%{agency_url}" target="_blank" rel="noopener noreferrer">%{agency_portal_name} website</a> for more information on how to submit documents.
           la_ldh: 'You can: <ul><li>Upload documents through the Self Service Portal online at <a href="https://mymedicaid.la.gov/" target="_blank" rel="noopener noreferrer">https://mymedicaid.la.gov/</a></li><li>Send documents through US Mail: Louisiana Medicaid/LaCHIP, P.O. Box 91283, Baton Rouge, LA 70821-9278</li><li>Email documents: <a href="mailto:MyMedicaid@la.gov">MyMedicaid@la.gov</a></li><li>Bring your documents to the Medicaid office of choice.</li></ul>'
         what_if_i_cant_use_this_title: What if I can't use this tool?
         who_is_this_for_body: You can use this tool if you have earned income in the last 90 days (even if you’re no longer working), and you can access your paystubs online or work for an app-based company like Uber, Lyft or Amazon Flex.
@@ -302,7 +302,7 @@ en:
     error_no_access: We weren't able to load payroll data for this account. Please click the link you received from your SNAP agency to try again.
     expired_invitations:
       show:
-        body_1: If you still need to verify your income, please submit your income information by visiting %{agency_acronym}'s website.
+        body_1_html: If you still need to verify your income, please submit your income information by visiting the <a href="%{agency_url}" target="_blank" rel="noopener noreferrer">%{agency_portal_name} website</a>.
         cta_button_html:
           la_ldh: <a href="%{agency_url}" class="usa-button" target="_blank" rel="noopener noreferrer">Visit LDH's website</a>
           sandbox: <a href="https://www.mass.gov/guides/how-to-contact-dta" class="usa-button" target="_blank" rel="noopener noreferrer">Learn more at CBV Test Agency</a>
@@ -312,13 +312,13 @@ en:
         back_button: Go back to employer search
         continue_button: Continue to review my report
         continue_to_review: Continue to review the income information you were able to find before you submit it to %{agency_acronym}.
-        exit_button_html: <a href="%{agency_contact_website}" class="usa-button" target="_blank" rel="noopener noreferrer">Exit and go to %{agency_full_name}</a>
+        exit_button_html: <a href="%{agency_contact_website}" class="usa-button" target="_blank" rel="noopener noreferrer">Exit and go to %{agency_portal_name}</a>
         header: How to report income if your employer or payroll provider isn’t listed
         more_jobs: If you have more jobs to report
         no_more_jobs: If you don't have more jobs to report
         not_listed_p1: If your employer or payroll provider isn’t listed on this site, you’ll need to share your income information for this job directly with %{agency_acronym}.
-        not_listed_p2: Visit %{agency_acronym}'s website for more information on how to submit documents.
-        not_listed_p2_link_html: Visit <a href="%{agency_url}" target="_blank" rel="noopener noreferrer">%{agency_acronym}'s website</a> for more information on how to submit documents.
+        not_listed_p2: Visit the %{agency_portal_name} website for more information on how to submit documents.
+        not_listed_p2_link_html: Visit the <a href="%{agency_url}" target="_blank" rel="noopener noreferrer">%{agency_portal_name} website</a> for more information on how to submit documents.
         you_can_search: You can search for another employer or payroll provider. This site supports employers with online payroll providers or app-based services. Examples include Amazon, Walmart, McDonald’s, Uber, DoorDash, Lyft, and Instacart.
     other_jobs:
       show:
@@ -329,7 +329,7 @@ en:
         header: Do you need to report any jobs outside Report My Income?
         header_html: Do you need to report any jobs <em>outside</em> Report My Income?
         header_sub_text: 'Tell us about any other jobs you’ve had in the past 90 days, even if you’re no longer at that job. This includes current or recent jobs you’ve had in the past 90 days that may:'
-        note_html: 'Note: If you’ve had other jobs in the past 90 days that you won’t report using Report My Income, you will need to submit that income information separately. <a href="%{agency_site}" target="_blank" rel="noopener noreferrer">Learn more on %{agency_acronym}.</a>'
+        note_html: 'Note: If you’ve had other jobs in the past 90 days that you won’t report using Report My Income, you will need to submit that income information separately. <a href="%{agency_site}" target="_blank" rel="noopener noreferrer">Learn more on %{agency_portal_name}.</a>'
         radio_no: No, I don’t have another job to report separately
         radio_yes: Yes, I have another job I’ll report separately
     payment_details:
@@ -440,7 +440,7 @@ en:
         survey: Take the 5 question survey
         whats_next: What's next?
         whats_next_1_li_1: If you couldn’t find a job or don’t get paystubs, report your income to %{agency_acronym} online, in person, or by mail.
-        whats_next_1_li_2_html: Go to <a href="%{agency_website}" target="_blank" rel="noopener noreferrer">%{agency_acronym}'s website</a>
+        whats_next_1_li_2_html: Go to the <a href="%{agency_website}" target="_blank" rel="noopener noreferrer">%{agency_portal_name} website</a>
         whats_next_1_title: Report other income, if needed.
         whats_next_2_li_1_html: We’d like to hear more about your experience using this site.
         whats_next_2_title: Help make this experience better.
@@ -452,7 +452,7 @@ en:
         edit: Edit
         header: Review your income report
         must_match:
-          default: This must match what is shown on your %{agency_acronym} application.
+          default: This must match what is shown on your %{agency_portal_name} application.
           la_ldh: This must match what is shown on your Medicaid benefits.
         none_found: We didn't find any payments from this employer in the past %{report_data_range}.
         none_found_description: This typically happens when you haven't received income from this job in the past %{report_data_range}. If you believe this is an error, please add a comment in the additional comments box. Otherwise, continue to the next page.
@@ -470,7 +470,7 @@ en:
         description: 'We were unable to connect to your employer''s system due to an error. To continue, you can:'
         option_1: Go back to employer search to retry adding this employer.
         option_2: Go back to employer search to add another job.
-        option_3: Submit your income information for this employer by visiting %{agency_acronym}'s website.
+        option_3: Submit your income information for this employer by visiting the %{agency_portal_name} website.
         title: We couldn't access your employer information
     synchronizations:
       indicators:
@@ -629,7 +629,7 @@ en:
       refresh: Refresh page
     home:
       description_1: Report My Income is a new tool designed to help you connect your income details from your employer or payroll provider directly to your benefits agency. We're currently testing this tool to ensure it works effectively.
-      description_2: Please note this pilot is currently available only to participants in Arizona and Louisiana.
+      description_2: Please note this pilot is currently available only to participants in select states.
       description_3: Visit your agency's website for more information on how to submit proof of income for your benefits.
       header: Welcome to Report My Income
       pilot_ended:
@@ -651,13 +651,18 @@ en:
     agency_acronym:
       az_des: DES/FAA
       la_ldh: LDH
-      pa_dhs: COMPASS
+      pa_dhs: DHS
       sandbox: CBV
     agency_full_name:
       az_des: Department of Economic Security/Family Assistance Administration
       la_ldh: Louisiana Department of Health
       pa_dhs: Pennsylvania Department of Human Services
       sandbox: CBV Test Agency
+    agency_portal_name:
+      az_des: DES/FAA
+      la_ldh: LDH
+      pa_dhs: COMPASS
+      sandbox: VMI
     app_name:
       az_des: MyFamilyBenefits
       pa_dhs: VerifyMyIncome

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -146,7 +146,7 @@ es:
         app_based_providers: Empleadores basados
         can_not_find_employer: No puedo encontrar a mi empleador o proveedor de nómina
         employer_not_listed: "¿Su empleador no está en la lista?"
-        exit_button_text: Salir y acceder al sitio web de %{agency_acronym}
+        exit_button_text: Salir y acceder al sitio web de %{agency_portal_name}
         header: Busque su empleador o proveedor de nómina
         no_results_steps1: Verifique si su empleador usa otro nombre empresarial o busque a su proveedor de nómina.
         no_results_steps2: Asegúrese de haber escrito correctamente los nombres, y busque de nuevo.
@@ -162,7 +162,7 @@ es:
         select: Seleccione
         to_continue: 'Si aún no ve enumerado a su empleador ni a su proveedor de nómina:'
         to_continue_li_1: Deberá enviar esa información de ingresos por separado.
-        to_continue_li_1_html: <a href="%{agency_contact_website}" target="_blank" rel="noopener noreferrer">Visite el sitio web del %{agency_acronym}</a> para informarse de otras formas de notificar sus ingresos.
+        to_continue_li_1_html: <a href="%{agency_contact_website}" target="_blank" rel="noopener noreferrer">Visite el sitio web del %{agency_portal_name}</a> para informarse de otras formas de notificar sus ingresos.
         to_continue_li_2: Si tiene otros trabajos que añadir, búsquelos.
         to_continue_li_3: Si no tiene otros trabajos que añadir aquí, puede salir de este sitio.
         to_continue_li_3_continue: Si no tiene otros trabajos que agregar aquí, continúe para revisar su reporte de ingresos.
@@ -181,10 +181,10 @@ es:
         step2_description: Podrá hacer una vista previa y aprobar todo lo que se comparta con %{agency_acronym}.
         step3: Envíe su información de pago.
         step3_description: La enviaremos automáticamente a %{agency_acronym}. Esto lo ayudará a demostrar y comprobar sus ingresos y puede ayudar a %{agency_acronym} a tomar una decisión más rápida.
-        subheader_html: 'Enviaremos los registros de pago de su(s) empleador(es) a %{agency_acronym} para verificar sus ingresos.<strong> La mayoría de las personas completan este proceso en aproximadamente 5 minutos.</strong> Solo siga estos pasos:'
-        what_if_i_cant_use_this_body_1: Si necesita declarar sus ingresos y no puede usar esta herramienta, deberá compartir, de manera directa, la información de sus ingresos para este trabajo con %{agency_acronym}.
+        subheader_html: 'Enviaremos los registros de pago de su(s) empleador(es) a %{agency_full_name} para verificar sus ingresos.<strong> La mayoría de las personas completan este proceso en aproximadamente 5 minutos.</strong> Solo siga estos pasos:'
+        what_if_i_cant_use_this_body_1: Si necesita declarar sus ingresos y no puede usar esta herramienta, deberá compartir, de manera directa, la información de sus ingresos para este trabajo con %{agency_portal_name}.
         what_if_i_cant_use_this_body_2_html:
-          default: Para obtener más información sobre cómo enviar documentos, visite el sitio web de <a href="%{agency_url}" target="_blank" rel="noopener noreferrer">%{agency_acronym}</a>.
+          default: Para obtener más información sobre cómo enviar documentos, visite el sitio web de <a href="%{agency_url}" target="_blank" rel="noopener noreferrer">%{agency_portal_name}</a>.
           la_ldh: 'Usted puede: <ul><li>Subir documentos a través del Portal de Autoservicio en línea en <a href="https://mymedicaid.la.gov/" target="_blank" rel="noopener noreferrer">https://mymedicaid.la.gov/</a></li><li>Enviar documentos por correo postal: Louisiana Medicaid/LaCHIP, P.O. Box 91283, Baton Rouge, LA 70821-9278</li><li>Enviar documentos por correo electrónico: <a href="mailto:MyMedicaid@la.gov">MyMedicaid@la.gov</a></li><li>Llevar sus documentos a la oficina de Medicaid de su elección.</li></ul>'
         what_if_i_cant_use_this_title: "¿Qué debo hacer si no puedo usar esta herramienta?"
         who_is_this_for_body: Puede usar esta herramienta si ha recibido ingresos en los últimos 90 días (incluso si ya no está trabajando). Además, le recordamos que puede acceder a sus recibos de pago en línea si brinda servicios a través de plataformas digitales, como Uber, Lyft o Amazon Flex.
@@ -195,7 +195,7 @@ es:
     error_no_access: No logramos cargar los datos de nómina para esta cuenta. Haga clic en el enlace que recibió de su agencia del SNAP para intentarlo de nuevo.
     expired_invitations:
       show:
-        body_1: Si todavía no termina de verificar sus ingresos, envíe su información de ingresos desde el mismo sitio web de %{agency_acronym}.
+        body_1_html: Si todavía no termina de verificar sus ingresos, envíe su información de ingresos desde el mismo sitio web de <a href="%{agency_url}" target="_blank" rel="noopener noreferrer">%{agency_portal_name}</a>.
         cta_button_html:
           la_ldh: <a href="%{agency_url}" class="usa-button" target="_blank" rel="noopener noreferrer">Visite el sitio web del LDH</a>
           sandbox: <a href="https://www.mass.gov/guides/how-to-contact-dta" class="usa-button" target="_blank" rel="noopener noreferrer">Obtenga más información en la Agencia de pruebas CBV</a>
@@ -205,13 +205,13 @@ es:
         back_button: Regrese a la búsqueda del empleador
         continue_button: Continúe a «Revisar mi reporte»
         continue_to_review: Continúe a revisar la información de ingresos que pudo encontrar antes de enviarla a %{agency_acronym}.
-        exit_button_html: <a href="%{agency_contact_website}" class="usa-button" target="_blank" rel="noopener noreferrer">Salir y acceder a %{agency_full_name}</a>
+        exit_button_html: <a href="%{agency_contact_website}" class="usa-button" target="_blank" rel="noopener noreferrer">Salir y acceder a %{agency_portal_name}</a>
         header: Cómo reportar ingresos si su empleador o proveedor de nómina no figura en la lista
         more_jobs: Si tiene más trabajos que reportar
         no_more_jobs: Si no tiene más trabajos que reportar
         not_listed_p1: Si su empleador o proveedor de nómina no están listados en este sitio, tendrá que compartir su información de ingresos por este trabajo directamente con %{agency_acronym}.
-        not_listed_p2: Para obtener más información sobre cómo enviar los documentos requeridos, visite el sitio web de %{agency_acronym}.
-        not_listed_p2_link_html: Visite <a href="%{agency_url}" target="_blank" rel="noopener noreferrer">el sitio web del %{agency_acronym}</a> para obtener más información sobre cómo enviar documentos.
+        not_listed_p2: Para obtener más información sobre cómo enviar los documentos requeridos, visite el sitio web de %{agency_portal_name}.
+        not_listed_p2_link_html: Visite <a href="%{agency_url}" target="_blank" rel="noopener noreferrer">el sitio web del %{agency_portal_name}</a> para obtener más información sobre cómo enviar documentos.
         you_can_search: Puede buscar otro empleador o proveedor de nómina. Este sitio apoya a los empleadores con proveedores de nómina en línea o servicios basados en aplicaciones. Algunos ejemplos son Amazon, Walmart, McDonald’s, Uber, DoorDash, Lyft e Instacart.
     other_jobs:
       show:
@@ -222,7 +222,7 @@ es:
         header: "¿Tiene que informar de algún trabajo sin usar la herramienta Reportar Mis Ingresos?"
         header_html: "¿Tiene que informar de algún trabajo <em>sin usar</em> la herramienta Reportar Mis Ingresos?"
         header_sub_text: 'Cuéntenos sobre cualquier otro trabajo que haya tenido en los últimos 90 días, incluso si ya no está en ese trabajo. Al hacerlo, incluya cualquier trabajo, actual o reciente, que haya tenido en los últimos 90 días que reúna estos requisitos:'
-        note_html: 'Importante: Si tuvo otros trabajos en los últimos 90 días que no va a reportar usando la herramienta Report My Income, debe enviar esa información de ingresos por separado. <a href="%{agency_site}" target="_blank" rel="noopener noreferrer">Más información en %{agency_acronym}.</a>'
+        note_html: 'Importante: Si tuvo otros trabajos en los últimos 90 días que no va a reportar usando la herramienta Report My Income, debe enviar esa información de ingresos por separado. <a href="%{agency_site}" target="_blank" rel="noopener noreferrer">Más información en %{agency_portal_name}.</a>'
         radio_no: No, no tengo otro trabajo que reportar por separado
         radio_yes: Sí, tengo otro trabajo que reportaré por separado
     payment_details:
@@ -321,7 +321,7 @@ es:
         survey: Responda esta encuesta de 5 preguntas
         whats_next: "¿Qué sigue?"
         whats_next_1_li_1: Si no pudo encontrar empleo o no dispone de talones de pago, reporte sus ingresos a %{agency_acronym} en línea, en persona o por correo.
-        whats_next_1_li_2_html: Visite el <a href="%{agency_website}" target="_blank" rel="noopener noreferrer">sitio web de %{agency_acronym}</a>
+        whats_next_1_li_2_html: Visite el <a href="%{agency_website}" target="_blank" rel="noopener noreferrer">sitio web de %{agency_portal_name}</a>
         whats_next_1_title: Reporte otros ingresos, si es necesario.
         whats_next_2_li_1_html: Nos gustaría saber más sobre su experiencia al usar este sitio.
         whats_next_2_title: Ayude a mejorar esta experiencia.
@@ -333,7 +333,7 @@ es:
         edit: Editar
         header: Revise su reporte de ingresos
         must_match:
-          default: Esto debe coincidir con lo que se muestra en su solicitud de %{agency_acronym}.
+          default: Esto debe coincidir con lo que se muestra en su solicitud de %{agency_portal_name}.
           la_ldh: Esto debe coincidir con lo que se muestra en sus beneficios de Medicaid.
         none_found: No encontramos ningún pago de este empleador en los últimos %{report_data_range}.
         none_found_description: Esto usualmente ocurre cuando usted no ha recibido ingresos por este trabajo en los últimos %{report_data_range}. Si cree que esto es un error, agregue un comentario en la casilla de comentarios adicionales. De lo contrario, continúe en la página siguiente.
@@ -351,7 +351,7 @@ es:
         description: 'No pudimos conectarnos al sistema de su empleador debido a un error. Para continuar, puede:'
         option_1: Volver a la búsqueda de empleadores para nuevamente intentar agregar este empleador.
         option_2: Volver a la búsqueda de empleadores para agregar otro trabajo.
-        option_3: Envíe su información de ingresos a este empleador visitando el sitio web de %{agency_acronym}.
+        option_3: Envíe su información de ingresos a este empleador visitando el sitio web de %{agency_portal_name}.
         title: No pudimos acceder a la información de su empleador
     synchronizations:
       indicators:
@@ -554,7 +554,7 @@ es:
       refresh: Actualizar página
     home:
       description_1: Reportar Mis Ingresos es una herramienta nueva que se diseñó para ayudarlo a vincular directamente los datos relacionados con sus ingresos con su agencia de beneficios. En este momento estamos probando esta herramienta para garantizar que funcione efectivamente.
-      description_2: Tenga en cuenta que, en este momento, este programa piloto solo está disponible para participantes que residan en Arizona y Louisiana.
+      description_2: Tenga en cuenta que, en este momento, este programa piloto solo está disponible para participantes en ciertos estados.
       description_3: Para obtener más información sobre cómo presentar comprobantes de ingresos para sus beneficios, visite el sitio web de su agencia.
       header: Bienvenido a Reportar Mis Ingresos
       pilot_ended:
@@ -576,13 +576,18 @@ es:
     agency_acronym:
       az_des: DES/FAA
       la_ldh: LDH
-      pa_dhs: COMPASS
+      pa_dhs: DHS
       sandbox: CBV
     agency_full_name:
       az_des: Departamento de Seguridad Económica de Arizona/Administración de Asistencia Familiar
       la_ldh: Departamento de Salud de Luisiana
       pa_dhs: Departamento de Servicios Humanos
       sandbox: Agencia de pruebas CBV
+    agency_portal_name:
+      az_des: DES/FAA
+      la_ldh: LDH
+      pa_dhs: COMPASS
+      sandbox: VMI
     app_name:
       az_des: MyFamilyBenefits
       pa_dhs: VerifyMyIncome

--- a/app/spec/controllers/cbv/employer_searches_controller_spec.rb
+++ b/app/spec/controllers/cbv/employer_searches_controller_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Cbv::EmployerSearchesController do
           get :show, params: { query: "no_results" }
           expect(response).to be_successful
           expect(response.body).to include("you can exit this site")
-          expect(response.body).to include("Exit and go to CBV")
+          expect(response.body).to include("Exit and go to the VMI website")
         end
       end
     end


### PR DESCRIPTION
## Summary
Separate out agency acronym from agency portal name

## Type of Change
Check all that apply.
- [ ] Bug
- [X] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
	session expiration page
		remove references to AZ and LA as pilot agencies
	landing page
		first paragraph, full agency name - '... from your employer(s) to <full agency name> to verify...'
	landing page - what if I can't use this tool
		replace agency acrynym with portal name
	employer search
		I cant find my employer
			'...income information for this job directly with <acronym>'
			button says 'exit and go to <portal name>'
			'vist the <portal name> website...'
	expired invitation
		'...visiting the <portal name> website...'
	employer is missing
		'...visit the <portland name> website...'
	other jobs page
		'...learn more on <portal name>...'
	success page
		'... go to the <portal name> website...'
	sync failure page
		'...by visiting the <portal name> website...'

## Checklist
- [ ] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
[if anything need special attention, note it here]
