### PR TITLE
remove unmapped employers

### DIFF
--- a/app/app/services/provider_search_service.rb
+++ b/app/app/services/provider_search_service.rb
@@ -28,9 +28,12 @@ class ProviderSearchService
     if @providers.include?(:argyle)
       argyle_service = Aggregators::Sdk::ArgyleService.new(@client_agency_config.argyle_environment)
 
-      results = argyle_service.employer_search(query)["results"].map do |result|
-        Aggregators::ResponseObjects::SearchResult.from_argyle(result)
-      end
+      results =
+        argyle_service.employer_search(query)
+                      .fetch("results")
+                      # only include employers that are mapped by argyle.
+                      .select { |r| r["mapping_status"].to_s.casecmp?("verified") } # keep only verified
+                      .map    { |r| Aggregators::ResponseObjects::SearchResult.from_argyle(r) }
 
       results = filter_results(results, BLOCKED_ARGYLE_EMPLOYERS)
     end

--- a/app/spec/services/provider_search_service_spec.rb
+++ b/app/spec/services/provider_search_service_spec.rb
@@ -31,10 +31,16 @@ RSpec.describe ProviderSearchService, type: :service do
         "Some Other Company, LLC"
       end
 
+      it "does not return unmapped employers" do
+        results = service.search(query)
+        # there are 8 records in the json source file, 3 of which are unmapped
+        expect(results.count { |r| r.provider_name == :argyle }).to eq(5)
+      end
+
       it "defaults to Argyle results if there are no Pinwheel exact matches" do
         results = service.search(query)
         expect(results.count { |r| r.provider_name == :pinwheel }).to eq(0)
-        expect(results.count { |r| r.provider_name == :argyle }).to eq(8)
+        expect(results.count { |r| r.provider_name == :argyle }).to eq(5)
       end
 
       context "when there *is* an exact match in Pinwheel" do
@@ -65,7 +71,7 @@ RSpec.describe ProviderSearchService, type: :service do
 
         results = service.search(query)
         expect(results.count { |r| r.provider_name == :pinwheel }).to eq(0)
-        expect(results.count { |r| r.provider_name == :argyle }).to eq(8)
+        expect(results.count { |r| r.provider_name == :argyle }).to eq(5)
       end
     end
 
@@ -75,7 +81,7 @@ RSpec.describe ProviderSearchService, type: :service do
       pinwheel_results = results.count { |item| item.provider_name == :pinwheel }
       argyle_results = results.count { |item| item.provider_name == :argyle }
       expect(pinwheel_results).to eq(0)
-      expect(argyle_results).to eq(8)
+      expect(argyle_results).to eq(5)
     end
 
     context "when only pinwheel is enabled" do
@@ -92,7 +98,7 @@ RSpec.describe ProviderSearchService, type: :service do
 
       it "returns results from argyle" do
         results = service.search("test")
-        expect(results.length).to eq(8)
+        expect(results.length).to eq(5)
       end
     end
   end


### PR DESCRIPTION
## Summary
Don't return unmapped employers from Argyle's search

## Type of Change
Check all that apply.
- [ ] Bug
- [X] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
* modify argyle search to ignore any employer that is not 'verified' on mapped status
* update rspec tests to test this functionality

## Checklist
- [X] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
[if anything need special attention, note it here]
