### PR TITLE
fix PA compass logo in the PDF

### DIFF
--- a/app/app/views/cbv/submits/show.pdf.erb
+++ b/app/app/views/cbv/submits/show.pdf.erb
@@ -9,8 +9,8 @@
     <span class="cbv-header__separator text-primary font-sans-md text-middle">|</span>
 
     <% if current_agency&.logo_path.present? %>
-      <div class="display-inline-block text-middle cbv-header__agency-logo--<%= current_agency.id %>">
-        <%= image_tag wicked_pdf_asset_base64(current_agency.logo_path) %>
+      <div class="display-inline-block text-middle">
+        <%= image_tag wicked_pdf_asset_base64(current_agency.logo_path), class: "cbv-header__agency-logo--#{current_agency.id}" %>
       </div>
     <% else %>
       <span class="text-middle font-sans-md text-no-wrap"><%= agency_translation(".pdf.agency_header_name") %></span>


### PR DESCRIPTION
## Summary
Fix issue where PA logo was to
<img width="981" height="628" alt="Screenshot 2025-10-07 at 9 14 31 PM" src="https://github.com/user-attachments/assets/cdeffd78-4d8e-466f-bd1f-a99ae7e7614a" />
<img width="782" height="590" alt="Screenshot 2025-10-07 at 9 16 14 PM" src="https://github.com/user-attachments/assets/5ae71b0c-df6d-4731-87f7-e1686191970d" />
o big 

## Type of Change
Check all that apply.
- [x] Bug
- [ ] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
* The CSS rules were incorrectly put on the wrapper instead of the img itself.  Fixed this.
* Tested both PA and AZ since this change is global in nature. 

## Checklist
- [ ] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
