### PR TITLE
Add redaction backstop

### DIFF
--- a/app/spec/services/data_retention_service_spec.rb
+++ b/app/spec/services/data_retention_service_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe DataRetentionService do
     end
   end
 
-  describe "#redact_complete_cbv_flows" do
+  describe "#redact_transmitted_cbv_flows" do
     let!(:cbv_flow_invitation) do
       create(:cbv_flow_invitation)
     end
@@ -220,24 +220,24 @@ RSpec.describe DataRetentionService do
       let(:now) { deletion_threshold - 1.minute }
 
       it "does not redact the CbvFlow" do
-        expect { service.redact_complete_cbv_flows }
+        expect { service.redact_transmitted_cbv_flows }
           .not_to change { cbv_flow.reload.attributes }
       end
 
       it "does not redact the CbvFlowInvitation" do
-        expect { service.redact_complete_cbv_flows }
+        expect { service.redact_transmitted_cbv_flows }
           .not_to change { cbv_flow_invitation.reload.attributes }
       end
 
       it "does not redact the CbvApplicant" do
-        expect { service.redact_complete_cbv_flows }
+        expect { service.redact_transmitted_cbv_flows }
           .not_to change { cbv_flow.cbv_applicant.reload.attributes }
       end
 
       it "does not redact an associated PayrollAccount" do
         payroll_account = create(:payroll_account, cbv_flow: cbv_flow)
 
-        expect { service.redact_complete_cbv_flows }
+        expect { service.redact_transmitted_cbv_flows }
           .not_to change { payroll_account.reload.attributes }
       end
     end
@@ -246,7 +246,7 @@ RSpec.describe DataRetentionService do
       let(:now) { deletion_threshold + 1.minute }
 
       it "redacts the incomplete CbvFlow" do
-        service.redact_complete_cbv_flows
+        service.redact_transmitted_cbv_flows
         expect(cbv_flow.reload).to have_attributes(
           end_user_id: "00000000-0000-0000-0000-000000000000",
           additional_information: {}
@@ -254,7 +254,7 @@ RSpec.describe DataRetentionService do
       end
 
       it "redacts the associated invitation" do
-        service.redact_complete_cbv_flows
+        service.redact_transmitted_cbv_flows
         expect(cbv_flow_invitation.reload).to have_attributes(
           auth_token: "REDACTED",
           redacted_at: within(1.second).of(now)
@@ -262,7 +262,7 @@ RSpec.describe DataRetentionService do
       end
 
       it "redacts the associated applicant" do
-        service.redact_complete_cbv_flows
+        service.redact_transmitted_cbv_flows
         expect(cbv_flow.cbv_applicant.reload).to have_attributes(
           first_name: "REDACTED"
         )
@@ -270,17 +270,110 @@ RSpec.describe DataRetentionService do
 
       it "redacts an associated PayrollAccount" do
         payroll_account = create(:payroll_account, cbv_flow: cbv_flow)
-        service.redact_complete_cbv_flows
+        service.redact_transmitted_cbv_flows
         expect(payroll_account.reload).to have_attributes(
           redacted_at: within(1.second).of(now)
         )
       end
 
       it "skips redacting already-redacted CbvFlows" do
-        service.redact_complete_cbv_flows
+        service.redact_transmitted_cbv_flows
 
         expect_any_instance_of(CbvFlow).not_to receive(:redact!)
-        service.redact_complete_cbv_flows
+        service.redact_transmitted_cbv_flows
+      end
+    end
+  end
+
+  describe "#redact_old_cbv_flows" do
+    let!(:cbv_flow_invitation) do
+      create(:cbv_flow_invitation)
+    end
+    let!(:cbv_flow) do
+      CbvFlow
+        .create_from_invitation(cbv_flow_invitation)
+        .tap do |cbv_flow|
+        cbv_flow.update(
+          end_user_id: "11111111-1111-1111-1111-111111111111",
+          additional_information: { "account-id" => "some string here" },
+          confirmation_code: "SANDBOX0002",
+          created_at: Time.new(2024, 8, 1, 12, 0, 0, "-04:00")
+        )
+      end
+    end
+    let(:service) { DataRetentionService.new }
+    let(:deletion_threshold) { cbv_flow.created_at + DataRetentionService::REDACT_OLD_RECORD_BACKSTOP }
+    let(:now) { Time.now }
+
+    around do |ex|
+      Timecop.freeze(now, &ex)
+    end
+
+    context "before the deletion threshold" do
+      let(:now) { deletion_threshold - 1.minute }
+
+      it "does not redact the CbvFlow" do
+        expect { service.redact_old_cbv_flows }
+          .not_to change { cbv_flow.reload.attributes }
+      end
+
+      it "does not redact the CbvFlowInvitation" do
+        expect { service.redact_old_cbv_flows }
+          .not_to change { cbv_flow_invitation.reload.attributes }
+      end
+
+      it "does not redact the CbvApplicant" do
+        expect { service.redact_old_cbv_flows }
+          .not_to change { cbv_flow.cbv_applicant.reload.attributes }
+      end
+
+      it "does not redact an associated PayrollAccount" do
+        payroll_account = create(:payroll_account, cbv_flow: cbv_flow)
+
+        expect { service.redact_old_cbv_flows }
+          .not_to change { payroll_account.reload.attributes }
+      end
+    end
+
+    context "after the deletion threshold" do
+      let(:now) { deletion_threshold + 1.minute }
+
+      it "redacts the incomplete CbvFlow" do
+        service.redact_old_cbv_flows
+        expect(cbv_flow.reload).to have_attributes(
+                                     end_user_id: "00000000-0000-0000-0000-000000000000",
+                                     additional_information: {}
+                                   )
+      end
+
+      it "redacts the associated invitation" do
+        service.redact_old_cbv_flows
+        expect(cbv_flow_invitation.reload).to have_attributes(
+                                                auth_token: "REDACTED",
+                                                redacted_at: within(1.second).of(now)
+                                              )
+      end
+
+      it "redacts the associated applicant" do
+        service.redact_old_cbv_flows
+        expect(cbv_flow.cbv_applicant.reload).to have_attributes(
+                                                   first_name: "REDACTED"
+                                                 )
+      end
+
+      it "redacts an associated PayrollAccount" do
+        payroll_account = create(:payroll_account, cbv_flow: cbv_flow)
+        service.redact_old_cbv_flows
+        expect(payroll_account.reload).to have_attributes(
+                                            redacted_at: within(1.second).of(now)
+                                          )
+      end
+
+      it "skips redacting already-redacted CbvFlows" do
+        service.redact_old_cbv_flows
+
+        expect_any_instance_of(CbvFlow).not_to receive(:redact!)
+        service.redact_old_cbv_flows
       end
     end
   end

--- a/infra/app/app-config/env-config/scheduled_jobs.tf
+++ b/infra/app/app-config/env-config/scheduled_jobs.tf
@@ -25,7 +25,7 @@ locals {
     # Follow data retention policy to redact data every day
     redact_data = {
       task_command        = ["bin/rails", "data_deletion:redact_all"]
-      schedule_expression = "cron(0 14 ? * * *)" # Every day at 2pm UTC (9am EST / 10am EDT)
+      schedule_expression = "cron(0 2 ? * * *)" # Every day at 2am UTC (9am EST / 10am EDT)
     }
   }
 }

--- a/infra/app/app-config/env-config/scheduled_jobs.tf
+++ b/infra/app/app-config/env-config/scheduled_jobs.tf
@@ -25,7 +25,7 @@ locals {
     # Follow data retention policy to redact data every day
     redact_data = {
       task_command        = ["bin/rails", "data_deletion:redact_all"]
-      schedule_expression = "cron(0 2 ? * * *)" # Every day at 2am UTC (9am EST / 10am EDT)
+      schedule_expression = "cron(0 10 ? * * *)" # Every day at 10am UTC (5am EST / 6am EDT)
     }
   }
 }


### PR DESCRIPTION
## Summary
Adds redact logic backstop - regardless of other conditions an unredacted flow will be redacted 30 days after creation. Change cron job to run the redaction at 10am UTC instead of 2pm UTC.

## Type of Change
Check all that apply.
- [X] Bug
- [X] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
* rename redact_complete_cbv_flows to redact_transmitted_cbv_flows
* add redact_old_cbv_flows
* add rspec tests for new method
* change cron job to be 10am utc

## Checklist
- [X] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
[if anything need special attention, note it here]
