### PR TITLE
PF-602 Refine usage of agency name variations

### DIFF
--- a/app/app/views/applicant_mailer/invitation_email.html.erb
+++ b/app/app/views/applicant_mailer/invitation_email.html.erb
@@ -17,7 +17,7 @@
 
       <p><%= agency_translation(".body_1", agency_acronym: agency_translation("shared.agency_acronym")) %></p>
       <p><%= agency_translation(".body_2_html", deadline: format_date(@cbv_flow_invitation.expires_at_local.to_s)) %></p>
-      <p><%= agency_translation(".body_3", app_name: agency_translation("shared.app_name")) %></p>
+      <p><%= agency_translation(".body_3", agency_portal: agency_translation("shared.agency_portal")) %></p>
 
       <p>
         <%= t(".button_caption") %>

--- a/app/app/views/cbv/entries/show.html.erb
+++ b/app/app/views/cbv/entries/show.html.erb
@@ -3,7 +3,8 @@
 <div data-controller="cbv-entry-page">
   <h1><%= title %></h1>
 
-  <p><%= t(".subheader_html", agency_full_name: agency_translation("shared.agency_full_name")) %></p>
+  <p><%= t(".subheader_html", agency_full_name: agency_translation("shared.agency_full_name"),
+           agency_acronym: agency_translation("shared.agency_acronym")) %></p>
 
   <ol class="usa-process-list">
     <li class="usa-process-list__item">

--- a/app/app/views/cbv/summaries/show.html.erb
+++ b/app/app/views/cbv/summaries/show.html.erb
@@ -36,7 +36,7 @@
 <!-- Generic link flow, no invitation -->
 <% if @cbv_flow.cbv_flow_invitation.blank? %>
 <h2><%= t(".your_information") %></h2>
-<p><%= agency_translation(".must_match", agency_portal_name: agency_translation("shared.agency_portal_name")) %></p>
+<p><%= agency_translation(".must_match", agency_acronym: agency_translation("shared.agency_acronym")) %></p>
 <div class="display-flex flex-justify font-body-md">
   <h3><%= t(".application_information") %></h3>
   <%= link_to t(".edit"), cbv_flow_applicant_information_path(force_show: true), class: "usa-link text-bold margin-0" %>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -111,7 +111,7 @@ en:
       body_2_html:
         default: This process is unique to you. Please don't share this invitation with anyone else. <strong>You have until %{deadline}, to complete your verification.</strong> Otherwise, you can request a new invitation.
       body_3:
-        default: This is an optional tool. If you decide that you don't want to use it, you can provide income documents via the %{app_name} app, fax, mail, or in-person.
+        default: This is an optional tool. If you decide that you don't want to use it, you can provide income documents via %{agency_portal}, fax, mail, or in-person.
       button: Verify your income
       button_caption: 'To verify your income with the SNAP Income Pilot, click the button below:'
       footer: This is an automatically generated message from your SNAP agency. Please don’t reply to this email.
@@ -275,7 +275,7 @@ en:
         step2_description: You will be able to preview and approve everything that is shared with %{agency_acronym}.
         step3: Submit your payment information.
         step3_description: We’ll automatically send it to %{agency_acronym}. This will help you prove your income and can help %{agency_acronym} get to a decision faster.
-        subheader_html: 'We’ll send your payment records from your employer(s) to %{agency_full_name} to verify your income. <strong>Most people complete this process in about 5 minutes.</strong> Just follow these steps:'
+        subheader_html: 'We’ll send your payment records from your employer(s) to %{agency_full_name} (%{agency_acronym}) to verify your income. <strong>Most people complete this process in about 5 minutes.</strong> Just follow these steps:'
         what_if_i_cant_use_this_body_1: If you need to verify your income and can’t use this tool, then you’ll need to share your income information for this job directly with %{agency_portal_name}.
         what_if_i_cant_use_this_body_2_html:
           default: Visit the <a href="%{agency_url}" target="_blank" rel="noopener noreferrer">%{agency_portal_name} website</a> for more information on how to submit documents.
@@ -398,7 +398,7 @@ en:
         application_or_recertification_date: SNAP application or recertification interview date
         consent_checkbox_label_html:
           az_des: Check this box to affirm under penalty of perjury that the information provided by you is true and complete to the best of your knowledge.<ul class="margin-y-2"><li>You agree to tell %{agency_acronym} about:<ul><li>any other income not included in this report,</li><li>or any errors found in the information gathered with this tool.</li></ul></li><li>You understand that providing accurate and complete information is your responsibility.</li><li>Any false or missing information may result in:<ul><li>an overpayment, which you must repay to %{agency_acronym},</li><li>or program disqualification.</li></ul></li></ul>By sending this report, you authorize its use for income verification by %{agency_acronym} and authorized personnel.
-          default: 'Check this box to confirm: <ul class="margin-y-2"><li>The information provided by you is true and complete to the best of your knowledge.</li><li>You agree to inform the %{agency_full_name} of any income not reflected in this report or any discrepancies found in the information gathered with this tool.</li><li>You understand that providing accurate and complete information is your responsibility, and any false or omitted information may have legal consequences.</li></ul> By sending this report, you authorize its use for income verification by authorized %{agency_acronym} personnel.'
+          default: 'Check this box to confirm: <ul class="margin-y-2"><li>The information provided by you is true and complete to the best of your knowledge.</li><li>You agree to inform the %{agency_full_name} (%{agency_acronym}) of any income not reflected in this report or any discrepancies found in the information gathered with this tool.</li><li>You understand that providing accurate and complete information is your responsibility, and any false or omitted information may have legal consequences.</li></ul> By sending this report, you authorize its use for income verification by authorized %{agency_acronym} personnel.'
           pa_dhs: "<strong>I agree and confirm:</strong><p><strong>I am sharing accurate information.</strong><br>The information I provided is true and complete to the best of my knowledge. I will not share the report if anything in it is incorrect.<p><strong>I will share any missing information.</strong><br>I agree to inform the PA Department of Human Services about any income that is not in this report.<p><strong>I am not sharing false information.</strong><br>I understand that I must share honest information. I understand I could get in legal trouble if I leave out information.<p><strong>I will share my income information.</strong><br>I allow the income information this webpage showed me to be shared with the PA Department of Human Services."
         legal_header: Legal agreement
         none_found: We didn't find any payments from this employer.
@@ -476,7 +476,7 @@ en:
         edit: Edit
         header: Review your income report
         must_match:
-          default: This must match what is shown on your %{agency_portal_name} application.
+          default: This must match what is shown on your %{agency_acronym} application.
           la_ldh: This must match what is shown on your Medicaid benefits.
         none_found: We didn't find any payments from this employer in the past %{report_data_range}.
         none_found_description: This typically happens when you haven't received income from this job in the past %{report_data_range}. If you believe this is an error, please add a comment in the additional comments box. Otherwise, continue to the next page.

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -65,7 +65,7 @@ es:
       body_2_html:
         default: Este proceso es solo para usted. Por favor, no comparta esta invitación con nadie más. <strong>Tiene hasta el %{deadline}, para realizar su verificación.</strong> De lo contrario, puede solicitar una nueva invitación.
       body_3:
-        default: Esta es una herramienta opcional. Si decide que no desea usarla, puede proveer los documentos de sus ingresos a través de la aplicación %{app_name}, fax, correo postal o en persona.
+        default: Esta es una herramienta opcional. Si decide que no desea usarla, puede proveer los documentos de sus ingresos a través de %{agency_portal}, fax, correo postal o en persona.
       button: Verifique sus ingresos
       button_caption: 'Para verificar sus ingresos con el SNAP Income Pilot, haga clic en el siguiente botón:'
       footer: Este es un mensaje generado automáticamente desde su agencia de SNAP. Por favor no conteste a este correo electrónico.
@@ -168,7 +168,7 @@ es:
         step2_description: Podrá hacer una vista previa y aprobar todo lo que se comparta con %{agency_acronym}.
         step3: Envíe su información de pago.
         step3_description: La enviaremos automáticamente a %{agency_acronym}. Esto lo ayudará a demostrar y comprobar sus ingresos y puede ayudar a %{agency_acronym} a tomar una decisión más rápida.
-        subheader_html: 'Enviaremos los registros de pago de su(s) empleador(es) a %{agency_full_name} para verificar sus ingresos.<strong> La mayoría de las personas completan este proceso en aproximadamente 5 minutos.</strong> Solo siga estos pasos:'
+        subheader_html: 'Enviaremos los registros de pago de su(s) empleador(es) a %{agency_full_name} (%{agency_acronym}) para verificar sus ingresos.<strong> La mayoría de las personas completan este proceso en aproximadamente 5 minutos.</strong> Solo siga estos pasos:'
         what_if_i_cant_use_this_body_1: Si necesita verificar sus ingresos y no puede usar esta herramienta, deberá compartir, de manera directa, la información de sus ingresos para este trabajo con %{agency_portal_name}.
         what_if_i_cant_use_this_body_2_html:
           default: Para obtener más información sobre cómo enviar documentos, visite el sitio web de <a href="%{agency_url}" target="_blank" rel="noopener noreferrer">%{agency_portal_name}</a>.
@@ -291,7 +291,7 @@ es:
         application_or_recertification_date: SNAP application or recertification interview date
         consent_checkbox_label_html:
           az_des: Marque esta casilla para confirmar, bajo pena de perjurio, que la información proporcionada es, a su leal saber y entender, verdadera y está completa.<ul class="margin-y-2"><li>Se compromete a informar %{agency_acronym} de cualquiera de lo siguiente:<ul><li>cualquier otro ingreso que no esté incluido en este informe;</li><li>o cualquier error que haya detectado en la información recopilada con esta herramienta.</li></ul></li><li>Comprende que usted es el único responsable de proporcionar información precisa y completa.</li><li>Por este motivo, cualquier información falsa o que no conste en el informe puede acarrear las siguientes consecuencias:<ul><li>un sobrepago, que debe reembolsar a %{agency_acronym};</li><li>o una inhabilitación para participar en el programa.</li></ul></li></ul>Al enviar este informe, autoriza su uso para fines de verificación de ingresos por parte de %{agency_acronym} y del personal autorizado de esta agencia.
-          default: 'Marque esta casilla para confirmar lo siguiente: <ul class="margin-y-2"><li>La información proporcionada es, a su leal saber y entender, verdadera y está completa.</li><li>Se compromete a informar a %{agency_full_name} de cualquier otro ingreso que no esté incluido en este informe o cualquier discrepancia que haya detectado en la información recopilada con esta herramienta.</li><li>Comprende que usted es el único responsable de proporcionar información precisa y completa. Por este motivo, cualquier información falsa o que no conste en el informe puede acarrear consecuencias legales.</li></ul> Al enviar este informe, autoriza su uso para fines de verificación de ingresos por parte del personal autorizado de %{agency_acronym}.'
+          default: 'Marque esta casilla para confirmar lo siguiente: <ul class="margin-y-2"><li>La información proporcionada es, a su leal saber y entender, verdadera y está completa.</li><li>Se compromete a informar a %{agency_full_name} (%{agency_acronym}) de cualquier otro ingreso que no esté incluido en este informe o cualquier discrepancia que haya detectado en la información recopilada con esta herramienta.</li><li>Comprende que usted es el único responsable de proporcionar información precisa y completa. Por este motivo, cualquier información falsa o que no conste en el informe puede acarrear consecuencias legales.</li></ul> Al enviar este informe, autoriza su uso para fines de verificación de ingresos por parte del personal autorizado de %{agency_acronym}.'
           pa_dhs: "<strong>Acepto y confirmo que:</strong><br><strong>Compartiré información precisa.</strong> La información que proporcioné es verdadera y completa a mi leal saber y entender. No compartiré el informe si algo en el mismo es incorrecto.<p><strong>Compartiré cualquier información faltante.</strong> Acepto informarle al Departamento de Servicios Humanos de PA sobre los ingresos que no estén en este informe. <p><strong>No compartiré información falsa.</strong> Entiendo que debo compartir información honesta. Entiendo que podría tener problemas legales si omito información.<p><strong>Compartiré la información de mis ingresos.</strong> Autorizo que la información sobre ingresos que me ha mostrado esta página web se comparta con el Departamento de Servicios Humanos de PA."
         legal_header: Acuerdo Legal
         none_found: No encontramos ningún pago de este empleador.
@@ -357,7 +357,7 @@ es:
         edit: Editar
         header: Revise su reporte de ingresos
         must_match:
-          default: Esto debe coincidir con lo que se muestra en su solicitud de %{agency_portal_name}.
+          default: Esto debe coincidir con lo que se muestra en su solicitud de %{agency_acronym}.
           la_ldh: Esto debe coincidir con lo que se muestra en sus beneficios de Medicaid.
         none_found: No encontramos ningún pago de este empleador en los últimos %{report_data_range}.
         none_found_description: Esto usualmente ocurre cuando usted no ha recibido ingresos por este trabajo en los últimos %{report_data_range}. Si cree que esto es un error, agregue un comentario en la casilla de comentarios adicionales. De lo contrario, continúe en la página siguiente.


### PR DESCRIPTION
## Summary
Make specified changes to strings used in content copy.

## Type of Change
Check all that apply.
- [ ] Bug
- [ ] Feature
- [X] Refactor
- [ ] Documentation update

## Changes

- /cbv/entry - add `agency_acronym` after `agency_full_name` 
- /cbv/submit - add `agency_acronym` after `agency_full_name` 
- /cbv/summary - change `agency_portal_name` to `agency_acronym` 
- /applicant_mailer/invitation_email.html.erb - adjust language from `app_name` to `agency_portal`

## Checklist
- [ ] Tests added/updated (if needed) - no tests broken, no tests added 
- [ ] Docs updated (if needed)

## Notes for Reviewers
### /cbv/entry 
before:
<img width="653" height="789" alt="entry" src="https://github.com/user-attachments/assets/fa54ec0f-d487-4be1-89ef-566fd61170ad" />

after:
sandbox/default
<img width="598" height="153" alt="Screenshot 2026-02-10 at 4 41 22 PM" src="https://github.com/user-attachments/assets/78a1b4e5-bb58-4ba1-b6d1-9c913e0988ab" />
<img width="622" height="154" alt="Screenshot 2026-02-10 at 4 47 18 PM" src="https://github.com/user-attachments/assets/326bfb36-86d3-47a4-9225-5a301a23d0db" />

AZ
<img width="621" height="171" alt="Screenshot 2026-02-10 at 5 11 02 PM" src="https://github.com/user-attachments/assets/c9c68e97-5f70-4db7-9219-7d20794e1e5c" />
<img width="654" height="191" alt="Screenshot 2026-02-10 at 5 11 16 PM" src="https://github.com/user-attachments/assets/732f15c4-9185-4f20-96c2-958cd91e3edf" />


PA
<img width="576" height="146" alt="Screenshot 2026-02-10 at 5 09 40 PM" src="https://github.com/user-attachments/assets/76d94979-7a0f-4d21-bc33-ba333bd0a11e" />
<img width="623" height="172" alt="Screenshot 2026-02-10 at 5 10 14 PM" src="https://github.com/user-attachments/assets/e303ad3a-53b8-44e0-9092-ff7dd355e29f" />




### /cbv/submit (default/sandbox only)
before:
<img width="539" height="744" alt="submit" src="https://github.com/user-attachments/assets/2c92ac23-6dce-450e-9114-d421a51c0441" />
after:
<img width="526" height="107" alt="Screenshot 2026-02-10 at 4 34 43 PM" src="https://github.com/user-attachments/assets/21255272-c950-45b1-b116-cd0f14d012b0" />

### /cbv/summary
before:
<img width="812" height="714" alt="summary" src="https://github.com/user-attachments/assets/aa6bfa3b-0e84-45fe-93f5-0db857c35d94" />

after:
sandbox/default
<img width="493" height="98" alt="Screenshot 2026-02-10 at 4 36 53 PM" src="https://github.com/user-attachments/assets/2ad22eea-8813-412e-860e-1536001b3b31" />
<img width="536" height="82" alt="Screenshot 2026-02-10 at 4 38 55 PM" src="https://github.com/user-attachments/assets/b9b577e5-3acc-4966-ad5c-14f19ed122ff" />


AZ
<img width="498" height="88" alt="Screenshot 2026-02-10 at 4 37 26 PM" src="https://github.com/user-attachments/assets/9c3889e1-ab77-40ef-8374-134e0cef5521" />
<img width="536" height="82" alt="Screenshot 2026-02-10 at 4 38 55 PM" src="https://github.com/user-attachments/assets/0dbb4638-cfa1-4aa0-b026-d5d8475f58f8" />


PA
<img width="510" height="89" alt="Screenshot 2026-02-10 at 4 37 52 PM" src="https://github.com/user-attachments/assets/fd2e692e-3424-494c-8990-897526c75b76" />
<img width="536" height="88" alt="Screenshot 2026-02-10 at 4 38 28 PM" src="https://github.com/user-attachments/assets/59fdeef0-ebed-4d2b-ae2b-521f9dabde96" />





---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213150168666606