### PR TITLE
PF-650: Show unemployment tips when searching for unemployment terms

### DIFF
--- a/app/app/controllers/cbv/employer_searches_controller.rb
+++ b/app/app/controllers/cbv/employer_searches_controller.rb
@@ -2,10 +2,12 @@ class Cbv::EmployerSearchesController < Cbv::BaseController
   before_action :check_webhooks_initialization_in_development
   after_action :track_accessed_search_event, only: :show
   after_action :track_applicant_searched_event, only: :show
+  after_action :track_unemployment_search_event, only: :show
 
   def show
     @query = search_params[:query]
     @employers = @query.blank? ? [] : provider_search(@query)
+    @show_unemployment_tips = UnemploymentSearchDetector.match?(@query)
     @has_payroll_account = @cbv_flow.payroll_accounts.any?
     @selected_tab = search_params[:type] || "payroll"
 
@@ -69,6 +71,20 @@ class Cbv::EmployerSearchesController < Cbv::BaseController
       client_agency_id: current_agency&.id,
       device_id: @cbv_flow.device_id,
       invitation_id: @cbv_flow.cbv_flow_invitation_id
+    })
+  end
+
+  def track_unemployment_search_event
+    return unless @show_unemployment_tips
+
+    event_logger.track(TrackEvent::ApplicantAccessedUnemployedHelp, request, {
+      time: Time.now.to_i,
+      cbv_applicant_id: @cbv_flow.cbv_applicant_id,
+      cbv_flow_id: @cbv_flow.id,
+      client_agency_id: current_agency&.id,
+      device_id: @cbv_flow.device_id,
+      invitation_id: @cbv_flow.cbv_flow_invitation_id,
+      unemployed_tips_source: "search"
     })
   end
 

--- a/app/app/services/unemployment_search_detector.rb
+++ b/app/app/services/unemployment_search_detector.rb
@@ -2,7 +2,7 @@
 
 module UnemploymentSearchDetector
   # Wildcard patterns: any query containing these substrings matches
-  WILDCARD_PATTERNS = %w[unemp desemp].freeze
+  WILDCARD_PATTERNS = [ "unemp", "desemp", "department of labor" ].freeze
 
   # Exact terms: query must match one of these exactly (after strip + downcase)
   EXACT_TERMS = [

--- a/app/app/services/unemployment_search_detector.rb
+++ b/app/app/services/unemployment_search_detector.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module UnemploymentSearchDetector
+  # Wildcard patterns: any query containing these substrings matches
+  WILDCARD_PATTERNS = %w[unemp desemp].freeze
+
+  # Exact terms: query must match one of these exactly (after strip + downcase)
+  EXACT_TERMS = [
+    "terminated", "fired", "let go",
+    "despedido", "despedida", "despido",
+    "terminado", "terminada", "me echaron"
+    # TODO: Add agency UI distribution terms once confirmed for AZ & PA
+  ].freeze
+
+  def self.match?(query)
+    return false if query.blank?
+
+    normalized = query.strip.downcase
+
+    WILDCARD_PATTERNS.any? { |pattern| normalized.include?(pattern) } ||
+      EXACT_TERMS.include?(normalized)
+  end
+end

--- a/app/app/views/cbv/employer_searches/_employer.html.erb
+++ b/app/app/views/cbv/employer_searches/_employer.html.erb
@@ -1,4 +1,8 @@
 <%= turbo_frame_tag "employers" do %>
+  <% if @show_unemployment_tips %>
+    <%= render partial: "unemployment_search_tips" %>
+  <% end %>
+
   <% if @query.present? %>
     <h2 class="site-preview-heading margin-bottom-2">
       <%= t("cbv.employer_searches.show.results") %> (<%= @employers.count %>)

--- a/app/app/views/cbv/employer_searches/_tips_for_unemployed.html.erb
+++ b/app/app/views/cbv/employer_searches/_tips_for_unemployed.html.erb
@@ -11,29 +11,7 @@
     data_options: { "unemployed-tips-target": "tipsAccordion" }
   ) do %>
 
-    <h5>
-      <%= t("cbv.employer_searches.show.unemployment_tips.tip1_heading") %>
-    </h5>
-    <p>
-      <%= t("cbv.employer_searches.show.unemployment_tips.tip1_description") %>
-    </p>
-
-    <h5>
-      <%= t("cbv.employer_searches.show.unemployment_tips.tip2_heading") %>
-    </h5>
-    <p>
-      <%= t("cbv.employer_searches.show.unemployment_tips.tip2_description", agency_full_name: agency_translation("shared.agency_full_name")) %>
-    </p>
-    <p class="text-italic">
-      <%= t("cbv.employer_searches.show.unemployment_tips.tip2_tip") %>
-    </p>
-
-    <h5>
-      <%= t("cbv.employer_searches.show.unemployment_tips.tip3_heading") %>
-    </h5>
-    <p>
-      <%= t("cbv.employer_searches.show.unemployment_tips.tip3_description", agency_full_name: agency_translation("shared.agency_full_name")) %>
-    </p>
+    <%= render partial: "unemployment_tip_content" %>
 
     <div>
       <button type="button"

--- a/app/app/views/cbv/employer_searches/_unemployment_search_tips.html.erb
+++ b/app/app/views/cbv/employer_searches/_unemployment_search_tips.html.erb
@@ -1,0 +1,19 @@
+<div class="margin-bottom-4" data-controller="click-tracker">
+  <%= render Uswds::Alert.new(type: :info, heading: t("cbv.employer_searches.show.unemployment_search_tips.heading")) do %>
+    <%= render partial: "unemployment_tip_content" %>
+
+    <div>
+      <%= link_to t("cbv.employer_searches.show.unemployment_search_tips.go_back"),
+          cbv_flow_employer_search_path,
+          class: "usa-button usa-button--outline margin-top-2",
+          data: {
+            turbo_frame: "_top",
+            action: "click->click-tracker#track",
+            element_type: ClickTracker::ElementType::InternalLink,
+            element_name: "go_back_to_search_from_unemployment_tips",
+            context_unemployed_tips_source: "search",
+            track_event: TrackEvent::ApplicantClosedUnemployedHelp
+          } %>
+    </div>
+  <% end %>
+</div>

--- a/app/app/views/cbv/employer_searches/_unemployment_search_tips.html.erb
+++ b/app/app/views/cbv/employer_searches/_unemployment_search_tips.html.erb
@@ -1,11 +1,11 @@
 <div class="margin-bottom-4" data-controller="click-tracker">
-  <%= render Uswds::Alert.new(type: :info, heading: t("cbv.employer_searches.show.unemployment_search_tips.heading")) do %>
+  <%= render Uswds::Alert.new(type: :info, heading: t("cbv.employer_searches.show.unemployment_search_tips.heading"), class: "usa-alert--no-icon") do %>
     <%= render partial: "unemployment_tip_content" %>
 
     <div>
       <%= link_to t("cbv.employer_searches.show.unemployment_search_tips.go_back"),
           cbv_flow_employer_search_path,
-          class: "usa-button usa-button--outline margin-top-2",
+          class: "usa-button--unstyled usa-link",
           data: {
             turbo_frame: "_top",
             action: "click->click-tracker#track",

--- a/app/app/views/cbv/employer_searches/_unemployment_tip_content.html.erb
+++ b/app/app/views/cbv/employer_searches/_unemployment_tip_content.html.erb
@@ -1,0 +1,23 @@
+<h5>
+  <%= t("cbv.employer_searches.show.unemployment_tips.tip1_heading") %>
+</h5>
+<p>
+  <%= t("cbv.employer_searches.show.unemployment_tips.tip1_description") %>
+</p>
+
+<h5>
+  <%= t("cbv.employer_searches.show.unemployment_tips.tip2_heading") %>
+</h5>
+<p>
+  <%= t("cbv.employer_searches.show.unemployment_tips.tip2_description", agency_full_name: agency_translation("shared.agency_full_name")) %>
+</p>
+<p class="text-italic">
+  <%= t("cbv.employer_searches.show.unemployment_tips.tip2_tip") %>
+</p>
+
+<h5>
+  <%= t("cbv.employer_searches.show.unemployment_tips.tip3_heading") %>
+</h5>
+<p>
+  <%= t("cbv.employer_searches.show.unemployment_tips.tip3_description", agency_full_name: agency_translation("shared.agency_full_name")) %>
+</p>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -272,6 +272,9 @@ en:
           tip2_tip: 'Tip: HR may have emailed you about how to log into the payroll system when your job ended.'
           tip3_description: Ask a manager or supervisor from your previous job to write a letter that shows when your job ended and when you were last paid. Submit that letter to %{agency_full_name}.
           tip3_heading: If you can’t log into the payroll system
+        unemployment_search_tips:
+          heading: Are you unemployed?
+          go_back: Go back to search
     entries:
       create:
         error: You must check the agreement checkbox to proceed.

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -262,6 +262,9 @@ en:
         search: Search
         select: Select
         type_the_full_name_tooltip: Type the full name using letters or numbers
+        unemployment_search_tips:
+          go_back: Go back to search
+          heading: Are you unemployed?
         unemployment_tips:
           close_message: Close this message
           link_text: I am currently unemployed
@@ -272,9 +275,6 @@ en:
           tip2_tip: 'Tip: HR may have emailed you about how to log into the payroll system when your job ended.'
           tip3_description: Ask a manager or supervisor from your previous job to write a letter that shows when your job ended and when you were last paid. Submit that letter to %{agency_full_name}.
           tip3_heading: If you can’t log into the payroll system
-        unemployment_search_tips:
-          heading: Are you unemployed?
-          go_back: Go back to search
     entries:
       create:
         error: You must check the agreement checkbox to proceed.

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -165,6 +165,9 @@ es:
           tip2_tip: 'Consejo: Es posible que Recursos Humanos le haya enviado un email sobre cómo iniciar sesión en el sistema de nómina cuando su trabajo terminó.'
           tip3_description: Pida a un(a) gerente o supervisor(a) de su trabajo anterior que escriba una carta que muestre cuándo terminó su trabajo y cuándo le pagaron por última vez. Envíe esa carta a %{agency_full_name}.
           tip3_heading: Si no puede iniciar sesión en el sistema de nómina
+        unemployment_search_tips:
+          heading: "¿Está desempleado?"
+          go_back: Volver a la búsqueda
     entries:
       create:
         error: Debe marcar la casilla de «acuerdo» para proceder.

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -155,6 +155,9 @@ es:
         search: Buscar
         select: Seleccione
         type_the_full_name_tooltip: Escribe el nombre completo usando letras o números
+        unemployment_search_tips:
+          go_back: Volver a la búsqueda
+          heading: "¿Está desempleado?"
         unemployment_tips:
           close_message: Cerrar este mensaje
           link_text: Estoy desempleado
@@ -165,9 +168,6 @@ es:
           tip2_tip: 'Consejo: Es posible que Recursos Humanos le haya enviado un email sobre cómo iniciar sesión en el sistema de nómina cuando su trabajo terminó.'
           tip3_description: Pida a un(a) gerente o supervisor(a) de su trabajo anterior que escriba una carta que muestre cuándo terminó su trabajo y cuándo le pagaron por última vez. Envíe esa carta a %{agency_full_name}.
           tip3_heading: Si no puede iniciar sesión en el sistema de nómina
-        unemployment_search_tips:
-          heading: "¿Está desempleado?"
-          go_back: Volver a la búsqueda
     entries:
       create:
         error: Debe marcar la casilla de «acuerdo» para proceder.

--- a/app/spec/controllers/cbv/employer_searches_controller_spec.rb
+++ b/app/spec/controllers/cbv/employer_searches_controller_spec.rb
@@ -75,6 +75,70 @@ RSpec.describe Cbv::EmployerSearchesController do
       end
     end
 
+    context "when user searches for an unemployment-related term" do
+      before do
+        argyle_stub_request_employer_search_response('bob')
+      end
+
+      render_views
+
+      it "renders the unemployment search tips alert" do
+        get :show, params: { query: "unemployed" }
+        expect(response).to be_successful
+        expect(response.body).to include("Are you unemployed?")
+        expect(response.body).to include("Go back to search")
+      end
+
+      it "still renders search results below the tips" do
+        get :show, params: { query: "unemployed" }
+        expect(response).to be_successful
+        expect(response.body).to include("Results")
+      end
+
+      it "tracks ApplicantAccessedUnemployedHelp with search source" do
+        allow(MixpanelEventTrackingJob).to receive(:perform_later).with("CbvPageView", anything, anything)
+        allow(MixpanelEventTrackingJob).to receive(:perform_later).with("ApplicantSearchedForEmployer", anything, anything)
+        expect(MixpanelEventTrackingJob).to receive(:perform_later).with(
+          "ApplicantAccessedUnemployedHelp", anything, hash_including(
+            cbv_applicant_id: cbv_flow.cbv_applicant_id,
+            cbv_flow_id: cbv_flow.id,
+            invitation_id: cbv_flow.cbv_flow_invitation_id,
+            unemployed_tips_source: "search"
+          )
+        )
+        get :show, params: { query: "unemployed" }
+      end
+
+      it "renders the go back link with correct tracking attributes" do
+        get :show, params: { query: "fired" }
+
+        html = Capybara.string(response.body)
+        go_back_link = html.find("[data-element-name='go_back_to_search_from_unemployment_tips']")
+        expect(go_back_link["data-track-event"]).to eq("ApplicantClosedUnemployedHelp")
+        expect(go_back_link["data-context-unemployed-tips-source"]).to eq("search")
+      end
+
+      it "matches Spanish terms" do
+        get :show, params: { query: "Despedido" }
+        expect(response).to be_successful
+        expect(response.body).to include("Are you unemployed?")
+      end
+    end
+
+    context "when user searches for a non-unemployment term" do
+      before do
+        argyle_stub_request_employer_search_response('bob')
+      end
+
+      render_views
+
+      it "does not render the unemployment search tips" do
+        get :show, params: { query: "walmart" }
+        expect(response).to be_successful
+        expect(response.body).not_to include("Are you unemployed?")
+      end
+    end
+
     context "when there are no employer search results" do
       before do
         argyle_stub_request_employer_search_response('bob')

--- a/app/spec/services/unemployment_search_detector_spec.rb
+++ b/app/spec/services/unemployment_search_detector_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe UnemploymentSearchDetector do
     end
 
     context "with English exact terms" do
-      ["terminated", "Terminated", "TERMINATED", "fired", "Fired", "let go", "Let Go", "LET GO"].each do |term|
+      [ "terminated", "Terminated", "TERMINATED", "fired", "Fired", "let go", "Let Go", "LET GO" ].each do |term|
         it "matches '#{term}'" do
           expect(described_class.match?(term)).to be true
         end
@@ -27,7 +27,7 @@ RSpec.describe UnemploymentSearchDetector do
     end
 
     context "with Spanish exact terms" do
-      ["despedido", "Despedida", "DESPIDO", "terminado", "Terminada", "me echaron", "Me Echaron"].each do |term|
+      [ "despedido", "Despedida", "DESPIDO", "terminado", "Terminada", "me echaron", "Me Echaron" ].each do |term|
         it "matches '#{term}'" do
           expect(described_class.match?(term)).to be true
         end

--- a/app/spec/services/unemployment_search_detector_spec.rb
+++ b/app/spec/services/unemployment_search_detector_spec.rb
@@ -10,6 +10,14 @@ RSpec.describe UnemploymentSearchDetector do
       end
     end
 
+    context "with Department of Labor wildcard terms" do
+      [ "Department of Labor", "department of labor", "AZ Department of Labor" ].each do |term|
+        it "matches '#{term}'" do
+          expect(described_class.match?(term)).to be true
+        end
+      end
+    end
+
     context "with English exact terms" do
       [ "terminated", "Terminated", "TERMINATED", "fired", "Fired", "let go", "Let Go", "LET GO" ].each do |term|
         it "matches '#{term}'" do

--- a/app/spec/services/unemployment_search_detector_spec.rb
+++ b/app/spec/services/unemployment_search_detector_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe UnemploymentSearchDetector do
+  describe ".match?" do
+    context "with English wildcard terms" do
+      %w[unemployed unemployment UNEMPLOYED Unemployment].each do |term|
+        it "matches '#{term}'" do
+          expect(described_class.match?(term)).to be true
+        end
+      end
+    end
+
+    context "with English exact terms" do
+      ["terminated", "Terminated", "TERMINATED", "fired", "Fired", "let go", "Let Go", "LET GO"].each do |term|
+        it "matches '#{term}'" do
+          expect(described_class.match?(term)).to be true
+        end
+      end
+    end
+
+    context "with Spanish wildcard terms" do
+      %w[desempleado desempleo DESEMPLEADO Desempleo].each do |term|
+        it "matches '#{term}'" do
+          expect(described_class.match?(term)).to be true
+        end
+      end
+    end
+
+    context "with Spanish exact terms" do
+      ["despedido", "Despedida", "DESPIDO", "terminado", "Terminada", "me echaron", "Me Echaron"].each do |term|
+        it "matches '#{term}'" do
+          expect(described_class.match?(term)).to be true
+        end
+      end
+    end
+
+    context "with non-matching terms" do
+      %w[walmart amazon target mcdonalds adp].each do |term|
+        it "does not match '#{term}'" do
+          expect(described_class.match?(term)).to be false
+        end
+      end
+    end
+
+    context "with edge cases" do
+      it "returns false for nil" do
+        expect(described_class.match?(nil)).to be false
+      end
+
+      it "returns false for blank string" do
+        expect(described_class.match?("")).to be false
+      end
+
+      it "returns false for whitespace-only string" do
+        expect(described_class.match?("   ")).to be false
+      end
+
+      it "handles leading/trailing whitespace" do
+        expect(described_class.match?("  unemployed  ")).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
When users search for unemployment-related terms (e.g., "unemployed", "fired", "despedido"), an always-visible alert with unemployment tips is displayed in the search results area, with any Argyle-mapped results still showing as cards beneath.

<img width="846" height="757" alt="image" src="https://github.com/user-attachments/assets/546ee84b-3570-4326-8901-3abc5e941e6f" />

https://github.com/user-attachments/assets/3653295d-572a-40d5-b131-90cbcda8a604



## Type of Change
Check all that apply.
- [ ] Bug
- [x] Feature
- [x] Refactor
- [ ] Documentation update

## Changes
- Add `UnemploymentSearchDetector` service with wildcard matching (`*unemp*`, `*desemp*`) and exact term matching (terminated, fired, let go, + Spanish equivalents). Case-insensitive, language-agnostic triggering.
- Extract shared `_unemployment_tip_content` partial from `_tips_for_unemployed` so both the existing accordion and the new search-triggered alert reuse the same tip content.
- Create `_unemployment_search_tips` partial using `Uswds::Alert` (always-visible, not an accordion) with a "Go back to search" link that returns to the default search page.
- Controller sets `@show_unemployment_tips` flag and conditionally renders the alert inside the turbo frame above search results.
- Track `ApplicantAccessedUnemployedHelp` (server-side, `unemployed_tips_source: "search"`) when tips are shown.
- Track `ApplicantClosedUnemployedHelp` (client-side click-tracker, `unemployed_tips_source: "search"`) when "Go back to search" is clicked.
- Add English and Spanish i18n keys for alert heading and go-back link text.

## Checklist
- [x] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
- The existing "I am currently unemployed" accordion at the bottom of the page remains visible during turbo frame search updates (it lives outside the turbo frame). Hiding it during unemployment searches is an option for a future iteration.
- Agency UI distribution terms (for AZ & PA) have a TODO placeholder in `UnemploymentSearchDetector` — pending Patricia's confirmation.
- `Laid-off`, `Dismissed`, `Discharged`, and `Downsizing` were intentionally excluded per the crossed-out items in the Figma spec.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213592853941387