### PR TITLE
PF-688: Fixing bug when using back button after employer search.

### DIFF
--- a/app/app/javascript/controllers/cbv/employer_search.js
+++ b/app/app/javascript/controllers/cbv/employer_search.js
@@ -14,12 +14,12 @@ export default class extends Controller {
   }
 
   async connect() {
-    this.errorHandler = this.element.addEventListener("turbo:frame-missing", this.onTurboError)
+    this.element.addEventListener("turbo:frame-missing", this.onTurboError)
     this.element.addEventListener("turbo:submit-start", this.onSearchStart)
   }
 
   disconnect() {
-    this.element.removeEventListener("turbo:frame-missing", this.errorHandler)
+    this.element.removeEventListener("turbo:frame-missing", this.onTurboError)
     this.element.removeEventListener("turbo:submit-start", this.onSearchStart)
   }
 

--- a/app/app/javascript/controllers/cbv/employer_search.js
+++ b/app/app/javascript/controllers/cbv/employer_search.js
@@ -15,10 +15,12 @@ export default class extends Controller {
 
   async connect() {
     this.errorHandler = this.element.addEventListener("turbo:frame-missing", this.onTurboError)
+    this.element.addEventListener("turbo:submit-start", this.onSearchStart)
   }
 
   disconnect() {
     this.element.removeEventListener("turbo:frame-missing", this.errorHandler)
+    this.element.removeEventListener("turbo:submit-start", this.onSearchStart)
   }
 
   onTurboError(event) {
@@ -27,6 +29,12 @@ export default class extends Controller {
     const location = event.detail.response.url
     event.detail.visit(location)
     event.preventDefault()
+  }
+
+  onSearchStart(event) {
+    const submitter = event.detail.formSubmission?.submitter
+
+    if (submitter) submitter.disabled = false
   }
 
   onSuccess(accountId) {

--- a/app/app/views/cbv/employer_searches/show.html.erb
+++ b/app/app/views/cbv/employer_searches/show.html.erb
@@ -27,10 +27,7 @@
 
   <div class="text-gray-50"><%= t(".company_examples") %></div>
 
-  <%= form_with url: cbv_flow_employer_search_path, method: :get,
-        class: "usa-search usa-search--big margin-bottom-4 margin-top-2",
-          html: { role: "search" },
-          data: { turbo_frame: "employers", turbo_action: "advance" } do |f| %>
+  <%= form_with url: cbv_flow_employer_search_path, method: :get, class: "usa-search usa-search--big margin-bottom-4 margin-top-2", html: { role: "search" }, data: { turbo_frame: "employers", turbo_action: "advance" } do |f| %>
     <%= f.label :query, "Search for your employer", class: "usa-sr-only" %>
     <%= f.text_field :query, value: @query, class: "usa-input", type: "search" %>
     <button

--- a/app/app/views/cbv/employer_searches/show.html.erb
+++ b/app/app/views/cbv/employer_searches/show.html.erb
@@ -27,7 +27,10 @@
 
   <div class="text-gray-50"><%= t(".company_examples") %></div>
 
-  <%= form_with url: cbv_flow_employer_search_path, method: :get, class: "usa-search usa-search--big margin-bottom-4 margin-top-2", html: { role: "search" }, data: { turbo_frame: "employers", turbo_action: "advance" } do |f| %>
+  <%= form_with url: cbv_flow_employer_search_path, method: :get,
+        class: "usa-search usa-search--big margin-bottom-4 margin-top-2",
+          html: { role: "search" },
+          data: { turbo_frame: "employers", turbo_action: "advance" } do |f| %>
     <%= f.label :query, "Search for your employer", class: "usa-sr-only" %>
     <%= f.text_field :query, value: @query, class: "usa-input", type: "search" %>
     <button

--- a/app/spec/javascript/controllers/employer_search.spec.js
+++ b/app/spec/javascript/controllers/employer_search.spec.js
@@ -30,18 +30,25 @@ describe("EmployerSearchController", () => {
     document.body.innerHTML = ""
   })
 
-  it("adds turbo:frame-missing listener on connect()", () => {
-    expect(stimulusElement.addEventListener).toBeCalledTimes(1)
+  it("adds turbo:frame-missing and turbo:submit-start listeners on connect()", () => {
+    expect(stimulusElement.addEventListener).toBeCalledTimes(2)
     expect(stimulusElement.addEventListener).toHaveBeenCalledWith(
       "turbo:frame-missing",
       expect.any(Function)
     )
+
+    expect(stimulusElement.addEventListener).toHaveBeenCalledWith(
+      "turbo:submit-start",
+      expect.any(Function)
+    )
   })
 
-  it("removes turbo:frame-missing listener on disconnect()", async () => {
+  it("removes turbo:frame-missing and turbo:submit-start listeners on disconnect()", async () => {
     await stimulusElement.remove()
-    expect(stimulusElement.removeEventListener).toBeCalledTimes(1)
-    expect(stimulusElement.removeEventListener.mock.calls[0][0]).toBe("turbo:frame-missing")
+    expect(stimulusElement.removeEventListener).toBeCalledTimes(2)
+    const removedEvents = stimulusElement.removeEventListener.mock.calls.map((c) => c[0])
+    expect(removedEvents).toContain("turbo:frame-missing")
+    expect(removedEvents).toContain("turbo:submit-start")
   })
 })
 
@@ -129,6 +136,44 @@ describe("EmployerSearchController with argyle", () => {
     expect(await fetchArgyleToken).toBeCalled()
     expect(await fetchArgyleToken.mock.results[0].value).toStrictEqual(mockArgyleAuthToken)
     expect(fetchArgyleToken.mock.calls[0]).toMatchSnapshot()
+  })
+})
+
+describe("EmployerSearchController onSearchStart", () => {
+  let controllerElement
+  let form
+  let submitButton
+
+  beforeEach(async () => {
+    controllerElement = document.createElement("div")
+    controllerElement.setAttribute("data-controller", "cbv-employer-search")
+
+    form = document.createElement("form")
+
+    submitButton = document.createElement("button")
+    submitButton.setAttribute("type", "submit")
+
+    form.appendChild(submitButton)
+    controllerElement.appendChild(form)
+    document.body.appendChild(controllerElement)
+
+    await window.Stimulus.register("cbv-employer-search", EmployerSearchController)
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  it("re-enables the submitter before the Turbo snapshot is captured", () => {
+    submitButton.disabled = true
+
+    const event = new CustomEvent("turbo:submit-start", {
+      bubbles: true,
+      detail: { formSubmission: { submitter: submitButton } },
+    })
+    form.dispatchEvent(event)
+
+    expect(submitButton.disabled).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Summary
PF-688: Fix submit button behavior on employer search page after using back button.

## Type of Change
Check all that apply.
- [x] Bug
- [ ] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
After searching for an employer, hitting the back button no longer leaves the search button disabled.

## Checklist
- [x] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
[if anything need special attention, note it here]


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214062041633241