### PR TITLE
PF-703: Use memory store caching in production.

### DIFF
--- a/app/config/environments/production.rb
+++ b/app/config/environments/production.rb
@@ -64,7 +64,7 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :memory_store, { size: 32.megabytes }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_name_prefix = "iv_cbv_payroll_production"


### PR DESCRIPTION
## Summary
FIXES PF-703: Use memory store caching in production.

## Type of Change
Check all that apply.
- [x] Bug
- [ ] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
Specify memory store caching in production. The default file_store cache has been triggering sporadic errors.

## Checklist
- [ ] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
[if anything need special attention, note it here]


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214360605298274