### PR TITLE
PF-673: Don't fire ApplicantClosedArgyleLinkFromErrorScreen in the happy path.

### DIFF
--- a/app/app/javascript/adapters/ArgyleModalAdapter.ts
+++ b/app/app/javascript/adapters/ArgyleModalAdapter.ts
@@ -1,9 +1,14 @@
 import { trackUserAction, fetchArgyleToken } from "@js/utilities/api.js"
 import { getDocumentLocale } from "@js/utilities/getDocumentLocale.js"
 import { ModalAdapter } from "./ModalAdapter.js"
-import { argyleUIEventToTrackingName, namespaceTrackingProperties } from "./argyleTracking.js"
+import {
+  argyleUIEventToTrackingName,
+  isArgyleErrorEvent,
+  namespaceTrackingProperties,
+} from "./argyleTracking.js"
 
 export default class ArgyleModalAdapter extends ModalAdapter {
+  private seenError = false
   async open() {
     const locale = getDocumentLocale()
 
@@ -71,6 +76,16 @@ export default class ArgyleModalAdapter extends ModalAdapter {
   }
 
   async onUIEvent(payload: ArgyleUIEvent) {
+    if (isArgyleErrorEvent(payload)) {
+      this.seenError = true
+    } else if (payload.name === "success - opened") {
+      this.seenError = false
+    }
+
+    if (payload.name === "link closed" && !this.seenError) {
+      return
+    }
+
     await trackUserAction(argyleUIEventToTrackingName(payload), {
       "argyle.eventName": payload.name,
       ...namespaceTrackingProperties(payload.properties),

--- a/app/app/javascript/adapters/argyleTracking.ts
+++ b/app/app/javascript/adapters/argyleTracking.ts
@@ -44,6 +44,15 @@ function loginEventToTrackingName(properties: ArgyleUIEvent["properties"]): stri
   return "ApplicantViewedArgyleLoginPage"
 }
 
+// Returns true if the UI event represents an error screen the user may have seen.
+export function isArgyleErrorEvent(event: ArgyleUIEvent): boolean {
+  if (event.name === "error - opened") return true
+  if (event.name === "account error - opened") return true
+  if (event.name === "login - opened" && event.properties.errorCode != null) return true
+
+  return false
+}
+
 // Convert Argyle UI events to tracking event names
 export function argyleUIEventToTrackingName(event: ArgyleUIEvent): string {
   switch (event.name) {

--- a/app/spec/javascript/adapters/ArgyleModalAdapter.spec.js
+++ b/app/spec/javascript/adapters/ArgyleModalAdapter.spec.js
@@ -325,12 +325,39 @@ describe("ArgyleModalAdapter", () => {
       expect(trackUserAction.mock.calls[1][1]).toMatchSnapshot()
     })
 
-    // New "link closed" event test
-    it("logs ApplicantClosedArgyleLinkFromErrorScreen for link closed event", async () => {
+    // "link closed" event tests
+    it("does not log ApplicantClosedArgyleLinkFromErrorScreen on happy-path close", async () => {
       await triggers.triggerUIEvent(mockLinkClosedEvent)
-      expect(trackUserAction).toHaveBeenCalledTimes(2)
-      expect(trackUserAction.mock.calls[1][0]).toBe("ApplicantClosedArgyleLinkFromErrorScreen")
-      expect(trackUserAction.mock.calls[1][1]).toMatchSnapshot()
+      expect(trackUserAction).not.toHaveBeenCalledWith(
+        "ApplicantClosedArgyleLinkFromErrorScreen",
+        expect.anything()
+      )
+    })
+    it("logs ApplicantClosedArgyleLinkFromErrorScreen when closed after link error screen", async () => {
+      await triggers.triggerUIEvent(mockErrorOpenedEvent)
+      await triggers.triggerUIEvent(mockLinkClosedEvent)
+      expect(trackUserAction).toHaveBeenCalledTimes(3)
+      expect(trackUserAction.mock.calls[2][0]).toBe("ApplicantClosedArgyleLinkFromErrorScreen")
+      expect(trackUserAction.mock.calls[2][1]).toMatchSnapshot()
+    })
+    it("logs ApplicantClosedArgyleLinkFromErrorScreen when closed after account error screen", async () => {
+      await triggers.triggerUIEvent(mockAccountErrorAuthenticationError)
+      await triggers.triggerUIEvent(mockLinkClosedEvent)
+      expect(trackUserAction).toHaveBeenCalledTimes(3)
+      expect(trackUserAction.mock.calls[2][0]).toBe("ApplicantClosedArgyleLinkFromErrorScreen")
+    })
+    it("logs ApplicantClosedArgyleLinkFromErrorScreen when closed after login error", async () => {
+      await triggers.triggerUIEvent(mockApplicantEncounteredArgyleAuthRequiredLoginError)
+      await triggers.triggerUIEvent(mockLinkClosedEvent)
+      expect(trackUserAction).toHaveBeenCalledTimes(3)
+      expect(trackUserAction.mock.calls[2][0]).toBe("ApplicantClosedArgyleLinkFromErrorScreen")
+    })
+    it("does not log ApplicantClosedArgyleLinkFromErrorScreen when user recovered to success after error", async () => {
+      await triggers.triggerUIEvent(mockErrorOpenedEvent)
+      await triggers.triggerUIEvent(mockSuccessOpenedEvent)
+      await triggers.triggerUIEvent(mockLinkClosedEvent)
+      expect(trackUserAction).toHaveBeenCalledTimes(3)
+      expect(trackUserAction.mock.calls[2][0]).not.toBe("ApplicantClosedArgyleLinkFromErrorScreen")
     })
 
     // Unknown event test

--- a/app/spec/javascript/adapters/__snapshots__/ArgyleModalAdapter.spec.js.snap
+++ b/app/spec/javascript/adapters/__snapshots__/ArgyleModalAdapter.spec.js.snap
@@ -19,7 +19,7 @@ exports[`ArgyleModalAdapter > event:other > logs ApplicantClickedArgyleLoginHelp
 }
 `;
 
-exports[`ArgyleModalAdapter > event:other > logs ApplicantClosedArgyleLinkFromErrorScreen for link closed event 1`] = `
+exports[`ArgyleModalAdapter > event:other > logs ApplicantClosedArgyleLinkFromErrorScreen when closed after link error screen 1`] = `
 {
   "argyle.eventName": "link closed",
   "argyle.userId": "test-user-id",


### PR DESCRIPTION
Only fire ApplicantClosedArgyleLinkFromErrorScreen when there has actually been an error.

## Summary
Only fire ApplicantClosedArgyleLinkFromErrorScreen when there has actually been an error. The event should not fire during normal happy path use.

## Type of Change
Check all that apply.
- [x] Bug
- [ ] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
[add concise bullet points of changes here]

## Checklist
- [x] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
[if anything need special attention, note it here]


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213841980254182