### PR TITLE
PF-691 update

### DIFF
--- a/app/config/initializers/content_security_policy.rb
+++ b/app/config/initializers/content_security_policy.rb
@@ -10,7 +10,7 @@ Rails.application.configure do
     policy.font_src :self, "https://*.cloudinary.com"
     policy.form_action :self, "https://login.microsoftonline.com"
     policy.frame_ancestors :self
-    policy.img_src :self, :data, "https://*.cloudinary.com", "https://cdn.getpinwheel.com"
+    policy.img_src :self, :data, "https://*.cloudinary.com", "https://cdn.getpinwheel.com", "https://static.verifymyincome.org"
     policy.object_src :none
     policy.script_src :self, *%w[
       https://js-agent.newrelic.com

--- a/app/lib/partner_config_loader.rb
+++ b/app/lib/partner_config_loader.rb
@@ -22,6 +22,12 @@ class PartnerConfigLoader
 
   REQUIRED_ATTRS = %w[partner_id name timezone transmission_method pay_income_days_w2 pay_income_days_gig].freeze
 
+  # Subdomain prefixes reserved for non-partner infrastructure. A partner
+  # claiming one of these would never receive traffic — DNS for the
+  # subdomain points elsewhere (e.g. `static` is the CloudFront-fronted
+  # static-assets CDN).
+  RESERVED_DOMAIN_PREFIXES = %w[static].freeze
+
   VALID_TRANSMISSION_METHODS = PartnerConfig.transmission_methods.keys.freeze
   VALID_DATA_TYPES = PartnerApplicationAttribute.data_types.keys.freeze
   VALID_PAY_INCOME_DAYS = [ 90, 182 ].freeze
@@ -68,6 +74,7 @@ class PartnerConfigLoader
     validate_required_attrs
     validate_transmission_method
     validate_pay_income_days
+    validate_domain
     validate_transmission_configs
     validate_application_attributes
     validate_translations
@@ -225,6 +232,14 @@ class PartnerConfigLoader
       unless VALID_PAY_INCOME_DAYS.include?(val.to_i)
         @errors << "Invalid #{attr} '#{val}'. Valid: #{VALID_PAY_INCOME_DAYS.join(', ')}"
       end
+    end
+  end
+
+  def validate_domain
+    domain = @data[:domain]
+    return if domain.blank?
+    if RESERVED_DOMAIN_PREFIXES.include?(domain.to_s.downcase)
+      @errors << "Invalid domain '#{domain}'. Reserved prefixes: #{RESERVED_DOMAIN_PREFIXES.join(', ')}"
     end
   end
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -129,7 +129,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -153,7 +152,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1726,7 +1724,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1761,7 +1758,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1944,7 +1940,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2955,7 +2950,6 @@
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -3382,7 +3376,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4251,7 +4244,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4458,7 +4450,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.2.tgz",
       "integrity": "sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -4507,7 +4498,6 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",

--- a/app/spec/lib/partner_config_loader_spec.rb
+++ b/app/spec/lib/partner_config_loader_spec.rb
@@ -152,6 +152,19 @@ RSpec.describe PartnerConfigLoader do
       expect(loader.errors).to include(/Invalid pay_income_days_w2/)
     end
 
+    it "errors on reserved domain prefix" do
+      valid_yaml["domain"] = "static"
+      yaml_file.reopen(yaml_file.path, "w")
+      yaml_file.write(valid_yaml.to_yaml)
+      yaml_file.rewind
+
+      loader = described_class.new(yaml_file.path)
+      loader.load!
+      loader.validate!
+      expect(loader.valid?).to be false
+      expect(loader.errors).to include(/Invalid domain 'static'/)
+    end
+
     it "errors on invalid application attribute data_type" do
       valid_yaml["application_attributes"][0]["data_type"] = "EBCDIC"
       yaml_file.reopen(yaml_file.path, "w")

--- a/infra/app/service/main.tf
+++ b/infra/app/service/main.tf
@@ -119,7 +119,8 @@ data "aws_iam_policy" "migrator_db_access_policy" {
 }
 
 data "aws_iam_policy" "static_assets_access" {
-  name = "dpw-${module.project_config.project_name}-static-assets-access"
+  count = var.environment_name == "prod" ? 1 : 0
+  name  = "dpw-${module.project_config.project_name}-static-assets-access"
 }
 
 resource "aws_iam_policy" "email_access_policy" {
@@ -223,10 +224,12 @@ module "service" {
 
   extra_environment_variables = merge(
     {
-      BUCKET_NAME               = local.storage_config.bucket_name
-      STATIC_ASSETS_BUCKET_NAME = "dpw-${module.project_config.project_name}-static-assets"
-      STATIC_ASSETS_CDN_URL     = "https://static.verifymyincome.org"
+      BUCKET_NAME           = local.storage_config.bucket_name
+      STATIC_ASSETS_CDN_URL = "https://static.verifymyincome.org"
     },
+    var.environment_name == "prod" ? {
+      STATIC_ASSETS_BUCKET_NAME = "dpw-${module.project_config.project_name}-static-assets"
+    } : {},
     local.ssm_env_vars,
     local.identity_provider_environment_variables,
     local.service_config.extra_environment_variables
@@ -245,11 +248,13 @@ module "service" {
 
   extra_policies = merge(
     {
-      storage_access       = module.storage.access_policy_arn,
-      static_assets_access = data.aws_iam_policy.static_assets_access.arn,
-      email_access         = aws_iam_policy.email_access_policy.arn,
-      sqs_queues_access    = module.service.sqs_access_policy_arn
+      storage_access    = module.storage.access_policy_arn,
+      email_access      = aws_iam_policy.email_access_policy.arn,
+      sqs_queues_access = module.service.sqs_access_policy_arn
     },
+    var.environment_name == "prod" ? {
+      static_assets_access = data.aws_iam_policy.static_assets_access[0].arn,
+    } : {},
     module.app_config.enable_identity_provider ? {
       identity_provider_access = module.identity_provider_client[0].access_policy_arn,
     } : {}


### PR DESCRIPTION
## Summary
Update the static bucket terraform files so that it doesn't cause demo tf to fail, add domain guard, update CSP policy so it can serve from prod to demo.

## Type of Change
Check all that apply.
- [ ] Bug
- [X] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
* Update CSP to allow demo to pull from static.verifymyincome.org
* Add 'reserved domain' concept to protect from dynamic override of 'static' domain in the future
* Gate s3 bucket on prod env only so demo tf changes don't fail  

## Checklist
- [ ] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
[if anything need special attention, note it here]
