### PR TITLE
PF-638: Correct mileage rounding calculations.

### DIFF
--- a/app/app/components/report/gig_monthly_summary_table_component.rb
+++ b/app/app/components/report/gig_monthly_summary_table_component.rb
@@ -70,15 +70,14 @@ class Report::GigMonthlySummaryTableComponent < ViewComponent::Base
     year = parse_month_safely(month_string).year
     cents_per_mile = self.federal_cents_per_mile(year)
 
-    # Note: we need to round miles to dollars x miles rate displayed
-    format_money(month_summary[:total_mileage].to_f.round(0) * cents_per_mile)
+    format_money(month_summary[:total_mileage].to_f * cents_per_mile)
   end
 
   def format_verified_mileage_expense_rate(month_summary, month_string)
     year = parse_month_safely(month_string).year
     cents_per_mile = self.federal_cents_per_mile(year)
     t("components.report.monthly_summary_table.dollars_times_miles",
-      dollar_amount: format_money_with_subcents(cents_per_mile), number_of_miles: month_summary[:total_mileage].to_f.round(0))
+      dollar_amount: format_money_with_subcents(cents_per_mile), number_of_miles: number_with_precision(month_summary[:total_mileage].to_f, precision: 2, strip_insignificant_zeros: true))
   end
 
   def format_total_gig_hours(month_summary)

--- a/app/spec/components/report/gig_monthly_summary_table_component_spec.rb
+++ b/app/spec/components/report/gig_monthly_summary_table_component_spec.rb
@@ -153,12 +153,12 @@ RSpec.describe Report::GigMonthlySummaryTableComponent, type: :component do
         subject = render_inline(described_class.new(argyle_report, payroll_account))
 
         expect(subject.css("thead tr.subheader-row th:nth-child(3)").to_html).to include "Verified mileage expenses"
-        expect(subject.css("tbody tr:nth-child(1) td:nth-child(3)").to_html).to include "$58.10"
-        expect(subject.css("tbody tr:nth-child(1) td:nth-child(3)").to_html).to include "($0.70 x 83 miles)"
-        expect(subject.css("tbody tr:nth-child(2) td:nth-child(3)").to_html).to include "$431.90"
-        expect(subject.css("tbody tr:nth-child(2) td:nth-child(3)").to_html).to include "($0.70 x 617 miles)"
-        expect(subject.css("tbody tr:nth-child(3) td:nth-child(3)").to_html).to include "$91.70"
-        expect(subject.css("tbody tr:nth-child(3) td:nth-child(3)").to_html).to include "($0.70 x 131 miles)"
+        expect(subject.css("tbody tr:nth-child(1) td:nth-child(3)").to_html).to include "$58.40"
+        expect(subject.css("tbody tr:nth-child(1) td:nth-child(3)").to_html).to include "($0.70 x 83.43 miles)"
+        expect(subject.css("tbody tr:nth-child(2) td:nth-child(3)").to_html).to include "$431.73"
+        expect(subject.css("tbody tr:nth-child(2) td:nth-child(3)").to_html).to include "($0.70 x 616.75 miles)"
+        expect(subject.css("tbody tr:nth-child(3) td:nth-child(3)").to_html).to include "$91.99"
+        expect(subject.css("tbody tr:nth-child(3) td:nth-child(3)").to_html).to include "($0.70 x 131.41 miles)"
       end
 
       it "emphasizes 'Definition names' in the explanation" do


### PR DESCRIPTION
## Summary
PF-638: Correct mileage rounding calculations. Multiply mileage x rate values before rounding, instead of rounding before multiplying.

## Type of Change
Check all that apply.
- [x] Bug
- [ ] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
Implements PF-638: Correct mileage rounding calculations. Multiply mileage x rate values before rounding, instead of rounding before multiplying.

## Checklist
- [x] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
[if anything need special attention, note it here]


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213547878535980