### PR TITLE
refactor to allow for proper dynamic partner parameters

### DIFF
--- a/app/Procfile.dev
+++ b/app/Procfile.dev
@@ -3,4 +3,4 @@ js: npm run build -- --watch
 css: npm run build:css:watch
 ngrok: ngrok http 3000 --log stdout
 moto: ./bin/moto_run.sh
-worker: ./bin/moto_sqs_queues.sh && ./bin/wait_for_queues.sh && bundle exec shoryuken -R -C config/shoryuken.yml
+worker: SHORYUKEN_LOG_LEVEL=WARN ./bin/moto_sqs_queues.sh && ./bin/wait_for_queues.sh && bundle exec shoryuken -R -C config/shoryuken.yml

--- a/app/app/controllers/api/invitations_controller.rb
+++ b/app/app/controllers/api/invitations_controller.rb
@@ -5,6 +5,11 @@ class Api::InvitationsController < ApplicationController
   before_action :authenticate
 
   def create
+    missing = missing_required_metadata_keys
+    if missing.any?
+      return render json: missing_required_errors(missing), status: :bad_request
+    end
+
     cbv_flow_invitation = CbvInvitationService.new(event_logger)
       .invite(cbv_flow_invitation_params, @current_user, delivery_method: nil)
 
@@ -19,35 +24,81 @@ class Api::InvitationsController < ApplicationController
       tokenized_url: cbv_flow_invitation.to_url,
       expiration_date: cbv_flow_invitation.expires_at_local,
       language: cbv_flow_invitation.language
-      # TODO: Determine if we actually want to echo this data back, maybe should be config param?
-      # agency_partner_metadata: allowed_metadata_params
     }, status: :created
   end
 
   private
 
+  def partner_config
+    @partner_config ||= ClientAgencyConfig.instance[@current_user.client_agency_id]
+  end
+
   def cbv_flow_invitation_params
     client_agency_id = @current_user.client_agency_id
 
-    # Permit top-level params of the invitation itself, while merging back in
-    # the allowed applicant attributes.
-    permitted = params.without(:client_agency_id, :agency_partner_metadata).permit(:language, :email_address, :user_id, :expiration_date, :expiration_days)
+    # Top-level invitation params (language, email, expiration).
+    permitted = params.without(:client_agency_id, :agency_partner_metadata).permit(
+      :language, :email_address, :user_id, :expiration_date, :expiration_days
+    )
+
+    # Split the incoming agency_partner_metadata hash by destination on
+    # cbv_applicants:
+    #   - The key matching `partner_identifier_name` → partner_identifier column.
+    #   - Keys that match real columns (date_of_birth, snap_application_date, etc.)
+    #     → assigned directly to those columns.
+    #   - Everything else → packed into the agency_partner_metadata jsonb.
+    incoming = unsafe_metadata_hash
+    identifier_name = partner_config.partner_identifier_name
+    real_columns = CbvApplicant.column_names
+
+    partner_identifier_value = nil
+    metadata = {}
+    direct_column_assignments = {}
+
+    partner_config.applicant_attributes.keys.each do |name|
+      key = name.to_s
+      value = incoming[name]
+      if identifier_name.present? && key == identifier_name.to_s
+        partner_identifier_value = value
+      elsif real_columns.include?(key)
+        direct_column_assignments[key.to_sym] = value
+      else
+        metadata[key] = value
+      end
+    end
+
+    cbv_applicant_attrs = {
+      client_agency_id: client_agency_id,
+      partner_identifier: partner_identifier_value,
+      agency_partner_metadata: metadata
+    }.merge(direct_column_assignments)
+
     permitted.deep_merge!(
       client_agency_id: client_agency_id,
       email_address: @current_user.email,
-      cbv_applicant_attributes: {
-        client_agency_id: client_agency_id,
-        **allowed_metadata_params.permit!
-      }
+      cbv_applicant_attributes: cbv_applicant_attrs
     )
   end
 
-  def allowed_metadata_params
-    # Allow params in the VALID_ATTRIBUTES array for the relevant agency
-    # CbvApplicant subclass.
-    ActionController::Parameters.new(
-      CbvApplicant.build_agency_partner_metadata(@current_user.client_agency_id) { |attr| params[:agency_partner_metadata][attr] }
-    )
+  def missing_required_metadata_keys
+    incoming = unsafe_metadata_hash
+    required_attrs = partner_config.applicant_attributes.select { |_name, attr| attr.required }
+    required_attrs.keys.reject { |name| incoming[name].present? }
+  end
+
+  # create output matching the expected data, drop anything unexpected.
+  def unsafe_metadata_hash
+    raw = params[:agency_partner_metadata]
+    return {} if raw.blank?
+    raw.respond_to?(:to_unsafe_h) ? raw.to_unsafe_h : raw.to_h
+  end
+
+  def missing_required_errors(missing)
+    {
+      errors: missing.map do |name|
+        { field: "agency_partner_metadata.#{name}", message: "is required" }
+      end
+    }
   end
 
   def authenticate

--- a/app/app/controllers/cbv/applicant_informations_controller.rb
+++ b/app/app/controllers/cbv/applicant_informations_controller.rb
@@ -51,7 +51,7 @@ class Cbv::ApplicantInformationsController < Cbv::BaseController
 
     return unless params[:skip_edit] == "true"
 
-    redirect_to next_path unless @cbv_applicant.has_applicant_attribute_missing?
+    redirect_to next_path if @cbv_applicant.missing_required_attributes.empty?
   end
 
   def redirect_when_in_invitation_flow

--- a/app/app/controllers/cbv/applicant_informations_controller.rb
+++ b/app/app/controllers/cbv/applicant_informations_controller.rb
@@ -43,7 +43,21 @@ class Cbv::ApplicantInformationsController < Cbv::BaseController
       attr == :date_of_birth ? { date_of_birth: [ :day, :month, :year ] } : attr
     }
 
-    params.fetch("cbv_applicant_#{@cbv_flow.client_agency_id}", {}).permit(cbv_applicant: permitted)
+    parsed = params.fetch("cbv_applicant_#{@cbv_flow.client_agency_id}", {})
+                   .permit(cbv_applicant: permitted)
+
+    # HTML forms send "" for empty inputs. CbvApplicant treats only literal
+    # `nil` as missing, so coerce blank scalar values to nil before
+    # mass-assignment to preserve form-validation UX. API callers (which
+    # don't go through this controller) can still send any non-nil value.
+    cbv_attrs = parsed[:cbv_applicant]
+    if cbv_attrs.is_a?(ActionController::Parameters)
+      cbv_attrs.each do |key, val|
+        cbv_attrs[key] = nil if val.is_a?(String) && val.empty?
+      end
+    end
+
+    parsed
   end
 
   def redirect_when_info_present

--- a/app/app/controllers/cbv/preview_controller.rb
+++ b/app/app/controllers/cbv/preview_controller.rb
@@ -174,9 +174,8 @@ class Cbv::PreviewController < ApplicationController
   def create_synced_flow(client_agency_id)
     cbv_applicant = CbvApplicant.create!(
       client_agency_id: client_agency_id,
-      first_name: "Preview",
-      last_name: "User",
-      case_number: "PREVIEW123",
+      partner_identifier: "PREVIEW123",
+      agency_partner_metadata: { "first_name" => "Preview", "last_name" => "User" },
       snap_application_date: Date.current
     )
 

--- a/app/app/mailers/caseworker_mailer.rb
+++ b/app/app/mailers/caseworker_mailer.rb
@@ -6,13 +6,13 @@ class CaseworkerMailer < ApplicationMailer
 
   def summary_email
     timestamp = Time.now.strftime("%Y%m%d%H%M%S")
-    case_number = @cbv_flow.cbv_applicant.case_number
-    filename = "#{case_number}_#{timestamp}_income_verification.pdf"
+    partner_identifier = @cbv_flow.cbv_applicant.partner_identifier
+    filename = "#{partner_identifier}_#{timestamp}_income_verification.pdf"
     attachments[filename] = generate_pdf
     mail(
       to: @email_address,
       subject: view_context.agency_translation("caseworker_mailer.summary_email.subject",
-                                case_number: case_number,
+                                case_number: partner_identifier,
                                 confirmation_code: @cbv_flow.confirmation_code),
     )
   end

--- a/app/app/mailers/weekly_report_mailer.rb
+++ b/app/app/mailers/weekly_report_mailer.rb
@@ -58,17 +58,19 @@ class WeeklyReportMailer < ApplicationMailer
     end
   end
 
-  def build_record(flow, applicant, invitation, agency)
+  def build_record(flow, applicant, invitation, partner)
     base_fields = {
       started_at: flow&.created_at,
       transmitted_at: flow&.transmitted_at,
       completed_at: flow&.consented_to_authorized_use_at
     }
 
-    # Add case_number if the agency has it as an applicant attribute
-    base_fields[:case_number] = applicant.case_number if agency.applicant_attributes.key?("case_number")
+    # add column header to represent the partner identifier
+    if partner.partner_identifier_name.present?
+      base_fields[partner.partner_identifier_name.to_sym] = applicant.partner_identifier
+    end
 
-    if agency.include_invitation_details_on_weekly_report
+    if partner.include_invitation_details_on_weekly_report
       base_fields[:email_address] = invitation&.email_address
       base_fields[:invited_at] = invitation&.created_at
     end

--- a/app/app/models/cbv_applicant.rb
+++ b/app/app/models/cbv_applicant.rb
@@ -46,11 +46,12 @@ class CbvApplicant < ApplicationRecord
 
   def redact!(fields = nil)
     fields_to_redact = fields || redactable_fields_from_config
-    raise "No fields to redact for #{client_agency_id}" unless fields_to_redact.present?
 
-    fields_to_redact.each do |field, type|
-      self[field] = Redactable::REDACTION_REPLACEMENTS[type]
+    if fields_to_redact.blank? && partner_identifier_redactable? == false && agency_partner_metadata.blank?
+      raise "No fields to redact for #{client_agency_id}"
     end
+
+    apply_redaction!(fields_to_redact || {})
 
     if income_changes.present?
       self[:income_changes] = redact_member_names_in_json(income_changes)
@@ -75,9 +76,10 @@ class CbvApplicant < ApplicationRecord
     self[:snap_application_date] = parse_date(value)
   end
 
-  def has_applicant_attribute_missing?
-    @required_applicant_attributes.any? do |attr|
-      self[attr].nil?
+  # retrurns the names of any attributes that are nil. false, [], {} are valid values for an attribute
+  def missing_required_attributes
+    @required_applicant_attributes.select do |attr|
+      self.send(attr).nil?
     end
   end
 
@@ -86,15 +88,11 @@ class CbvApplicant < ApplicationRecord
   end
 
   def validate_required_applicant_attributes
-    missing_attrs = @required_applicant_attributes.reject do |attr|
-      self.send(attr).present?
-    end
+    missing_attrs = missing_required_attributes
 
-    if missing_attrs.any?
-      missing_attrs.each do |attr|
-        errors.add(attr, I18n.t("cbv.applicant_informations.#{client_agency_id}.fields.#{attr}.blank",
-          default: I18n.t("cbv.applicant_informations.default.fields.#{attr}.blank", default: "is required")))
-      end
+    missing_attrs.each do |attr|
+      errors.add(attr, I18n.t("cbv.applicant_informations.#{client_agency_id}.fields.#{attr}.blank",
+        default: I18n.t("cbv.applicant_informations.default.fields.#{attr}.blank", default: "is required")))
     end
 
     missing_attrs
@@ -110,14 +108,21 @@ class CbvApplicant < ApplicationRecord
     @required_applicant_attributes = get_required_applicant_attributes
   end
 
-  # Reset the applicant attributes to nil by removing any non-symbol keys i.e. { date_of_birth: [ :day, :month, :year ] }
-  # and then setting the attributes to nil.
-  # Need to skip snap_application_date because this class has a vlaidation on it.
+  # reset applicant custom attribute to nil
   def reset_applicant_attributes
-    clear_attributes = applicant_attributes
-      .reject { |key| !key.is_a?(Symbol) || key == :snap_application_date }
-      .index_with(nil)
-    update!(clear_attributes)
+    real_columns = self.class.column_names
+    applicant_attributes
+      .each do |key|
+        next unless key.is_a?(Symbol)
+        next if key == :snap_application_date
+
+        if real_columns.include?(key.to_s)
+          self[key] = nil
+        else
+          write_applicant_attribute(key, nil)
+        end
+      end
+    save!
   end
 
   def is_applicant_attribute_required?(attribute)
@@ -125,7 +130,50 @@ class CbvApplicant < ApplicationRecord
     .include?(attribute)
   end
 
+  # logic to ensure that the jsonb column partner custom attributes can be accessed via reflection
+  def method_missing(method_name, *args, &block)
+    name = method_name.to_s
+    is_setter = name.end_with?("=")
+    attr_name = is_setter ? name.chomp("=") : name
+
+    if is_setter && writable_applicant_attribute?(attr_name)
+      write_applicant_attribute(attr_name, args.first)
+    elsif !is_setter && readable_applicant_attribute?(attr_name)
+      read_applicant_attribute(attr_name)
+    else
+      super
+    end
+  end
+
+  # dynamic property reading and writing for the jsonb attributes that are not actual entity columns in the db
+  def respond_to_missing?(method_name, include_private = false)
+    name = method_name.to_s
+    if name.end_with?("=")
+      writable_applicant_attribute?(name.chomp("=")) || super
+    else
+      readable_applicant_attribute?(name) || super
+    end
+  end
+
   private
+
+  # verify that the attribute name being used here is actually defined as part of the partners custom attributes
+  def writable_applicant_attribute?(name)
+    dynamic_applicant_attribute?(name)
+  end
+
+  def readable_applicant_attribute?(name)
+    dynamic_applicant_attribute?(name)
+  end
+
+  def dynamic_applicant_attribute?(name)
+    return false if name.blank?
+    return false if self.class.column_names.include?(name)
+    cfg = agency_config
+    return false unless cfg
+    attrs = cfg.applicant_attributes
+    attrs.key?(name) || attrs.key?(name.to_sym)
+  end
 
   def parse_date(value)
     return value if value.is_a?(Date)
@@ -145,6 +193,48 @@ class CbvApplicant < ApplicationRecord
     agency_config.applicant_attributes
       .select { |_name, attr| attr.redactable }
       .each_with_object({}) { |(name, attr), h| h[name.to_sym] = attr.redact_type.to_sym }
+  end
+
+  def partner_identifier_redactable?
+    return false unless agency_config && agency_config.partner_identifier_name
+    attr = agency_config.applicant_attributes[agency_config.partner_identifier_name]
+    !!(attr && attr.redactable)
+  end
+
+  # Apply redaction to whatever backs each field — real columns get assigned
+  # directly; partner-defined attributes get routed through write_applicant_attribute
+  # so the jsonb / partner_identifier column is updated correctly.
+  def apply_redaction!(fields_to_redact)
+    real_columns = self.class.column_names
+    fields_to_redact.each do |field, type|
+      replacement = Redactable::REDACTION_REPLACEMENTS[type]
+      if real_columns.include?(field.to_s)
+        self[field] = replacement
+      else
+        write_applicant_attribute(field, replacement)
+      end
+    end
+  end
+
+  # Read a partner-defined applicant attribute. The value lives either in the
+  # `partner_identifier` column (if `name` matches the agency's
+  # `partner_identifier_name`) or in the `agency_partner_metadata` jsonb.
+  # Real ActiveRecord columns (e.g. `snap_application_date`) take precedence
+  # via the `super` chain in method_missing.
+  def read_applicant_attribute(name)
+    name = name.to_s
+    return partner_identifier if name == agency_config&.partner_identifier_name.to_s
+    (agency_partner_metadata || {})[name]
+  end
+
+  def write_applicant_attribute(name, value)
+    name = name.to_s
+    if name == agency_config&.partner_identifier_name.to_s
+      self.partner_identifier = value
+    else
+      self.agency_partner_metadata = (agency_partner_metadata || {}).merge(name => value)
+    end
+    value
   end
 
   def redact_member_names_in_json(json_array)

--- a/app/app/models/cbv_flow_invitation.rb
+++ b/app/app/models/cbv_flow_invitation.rb
@@ -86,18 +86,16 @@ class CbvFlowInvitation < ApplicationRecord
   def applicant_information
     return unless cbv_applicant.present?
 
-    required_attrs = cbv_applicant.required_applicant_attributes
+    cbv_applicant.required_applicant_attributes.each do |attr|
+      next if cbv_applicant.send(attr).present?
 
-    if required_attrs.include?(:first_name) && cbv_applicant.first_name.blank?
-      errors.add(:'cbv_applicant.first_name', I18n.t("activerecord.errors.models.cbv_applicant.attributes.first_name.blank"))
-    end
-
-    if required_attrs.include?(:last_name) && cbv_applicant.last_name.blank?
-      errors.add(:'cbv_applicant.last_name', I18n.t("activerecord.errors.models.cbv_applicant.attributes.last_name.blank"))
-    end
-
-    if required_attrs.include?(:snap_application_date) && cbv_applicant.snap_application_date.blank?
-      errors.add(:'cbv_applicant.snap_application_date', I18n.t("activerecord.errors.models.cbv_applicant.attributes.snap_application_date.invalid_date"))
+      errors.add(
+        :"cbv_applicant.#{attr}",
+        I18n.t(
+          "activerecord.errors.models.cbv_applicant.attributes.#{attr}.blank",
+          default: "is required"
+        )
+      )
     end
   end
 

--- a/app/app/services/data_retention_service.rb
+++ b/app/app/services/data_retention_service.rb
@@ -84,12 +84,19 @@ class DataRetentionService
     end
   end
 
-  # Use after conducting a user test or other time we want to manually redact a
-  # specific person's data in the system. Class level method for calling from terminal.
-  def self.manually_redact_by_case_number!(case_number)
+  # manually redact all instances of a specific identifier for a partner. the partner identifier is not unique per partner (could create more
+  # than one invitation for a single applicant). This is a manual way to redact records.
+  def self.manually_redact_by_partner_identifier!(client_agency_id, partner_identifier)
+    applicants = CbvApplicant.where(
+      client_agency_id: client_agency_id,
+      partner_identifier: partner_identifier
+    )
+    raise ActiveRecord::RecordNotFound, "No CbvApplicant found for client_agency_id=#{client_agency_id.inspect} partner_identifier=#{partner_identifier.inspect}" if applicants.empty?
+
     service = new
-    applicant = CbvApplicant.find_by!(case_number: case_number)
-    applicant.cbv_flows.each { |cbv_flow| service.send(:redact_cbv_flow, cbv_flow) }
+    applicants.find_each do |applicant|
+      applicant.cbv_flows.each { |cbv_flow| service.send(:redact_cbv_flow, cbv_flow) }
+    end
   end
 
   private
@@ -120,15 +127,5 @@ class DataRetentionService
 
     Rails.logger.error "Unable to delete Argyle User #{argyle_user_id} - #{ex.message}"
     GenericEventTracker.new.track("DataRedactionFailure", nil, { argyle_user_id: argyle_user_id })
-  end
-
-  # retroactive redaction for case numbers by agency
-  # TODO: This is a one off. Should be updated to just be something like retroactive_redact(agency_id,field_name)
-  def self.redact_case_numbers_by_agency(agency_id)
-    applicants = CbvApplicant.where(client_agency_id: agency_id)
-    applicants.find_each(batch_size: 200) do |applicant|
-      applicant.redact!({ case_number: :string })
-    end
-    Rails.logger.info "Redacted #{applicants.length} applicants"
   end
 end

--- a/app/app/services/recently_submitted_cases_csv.rb
+++ b/app/app/services/recently_submitted_cases_csv.rb
@@ -4,11 +4,14 @@ class RecentlySubmittedCasesCsv < CsvGenerator
   end
 
   def generate_csv(cbv_flows)
+    # dynamic expiration header based on configured partner identifier
+    identifier_header = (@agency.partner_identifier_name || "partner_identifier").to_sym
+
     data = cbv_flows.map do |cbv_flow|
       invitation = cbv_flow.cbv_flow_invitation
 
       {
-        case_number: cbv_flow.cbv_applicant.case_number,
+        identifier_header => cbv_flow.cbv_applicant.partner_identifier,
         confirmation_code: cbv_flow.confirmation_code,
         cbv_link_created_timestamp: invitation ? @agency.format_timestamp(cbv_flow.cbv_flow_invitation.created_at) : nil,
         cbv_link_clicked_timestamp: @agency.format_timestamp(cbv_flow.created_at),

--- a/app/bin/moto_run.sh
+++ b/app/bin/moto_run.sh
@@ -24,6 +24,9 @@ fi
 
 echo "[moto] Starting Moto on ${MOTO_ENDPOINT} ..."
 
+# Quiet by default. Set MOTO_QUIET=false to see every WSGI access-log line.
+MOTO_QUIET="${MOTO_QUIET:-true}"
+
 # Check if moto_server is available, if not try to activate venv
 if ! command -v moto_server >/dev/null 2>&1; then
   echo "[moto] moto_server not found in PATH, looking for virtual environment..."
@@ -47,4 +50,14 @@ if ! command -v moto_server >/dev/null 2>&1; then
   fi
 fi
 
-exec moto_server -p "${PORT}"
+if [ "${MOTO_QUIET}" = "true" ]; then
+  # `--line-buffered` keeps grep flushing each line so foreman renders in real time.
+  # `set +o pipefail` so a non-matching line doesn't kill the script via grep's exit 1
+  # (we only care about moto_server's exit status).
+  set +o pipefail
+  # Filter only 2xx access lines; 4xx / 5xx (and anything that isn't a routine
+  # success) still surface in the foreman console.
+  moto_server -p "${PORT}" 2>&1 | grep --line-buffered -vE '"(GET|POST|PUT|DELETE|HEAD|PATCH|OPTIONS) .+ HTTP/1\.[01]" 2[0-9]{2} '
+else
+  exec moto_server -p "${PORT}"
+fi

--- a/app/config/initializers/quiet_dev_logs.rb
+++ b/app/config/initializers/quiet_dev_logs.rb
@@ -1,0 +1,20 @@
+# Suppress chatty INFO-level output in `bin/dev` — keeps the foreman console
+# focused on requests + errors. Production/test behavior is unchanged.
+return unless Rails.env.development?
+
+Rails.application.config.after_initialize do
+  # ActiveJob notifications: drops "Performing X / Performed X" + "Enqueued X"
+  # lines fired by MixpanelEventTrackingJob, CaseWorkerTransmitterJob,
+  # CsvToSftpReportDelivererJob, NewRelicEventTrackingJob, etc.
+  ActiveJob::Base.logger = Logger.new(File::NULL)
+
+  # Shoryuken's polling/receive-loop chatter from the worker process.
+  if defined?(Shoryuken)
+    Shoryuken.logger.level = Logger::WARN
+  end
+
+  # NewRelic agent's own log level is controlled by `log_level` in
+  # config/newrelic.yml (set to `error` for the development env). The
+  # AgentLogger doesn't expose a runtime `level=` setter the way stdlib
+  # Logger does, so all NewRelic quieting happens via that YAML.
+end

--- a/app/db/migrate/20260505200000_add_metadata_columns_for_dynamic_applicant_attributes.rb
+++ b/app/db/migrate/20260505200000_add_metadata_columns_for_dynamic_applicant_attributes.rb
@@ -1,0 +1,9 @@
+class AddMetadataColumnsForDynamicApplicantAttributes < ActiveRecord::Migration[7.2]
+  def change
+    add_column :cbv_applicants, :agency_partner_metadata, :jsonb, null: false, default: {}
+    add_column :cbv_applicants, :partner_identifier, :string
+    add_column :partner_configs, :partner_identifier_name, :string
+
+    add_index :cbv_applicants, :partner_identifier
+  end
+end

--- a/app/db/migrate/20260505200001_backfill_partner_identifier_and_metadata.rb
+++ b/app/db/migrate/20260505200001_backfill_partner_identifier_and_metadata.rb
@@ -1,0 +1,29 @@
+class BackfillPartnerIdentifierAndMetadata < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def up
+    # Legacy backfill for existing partners before they get the updated dynamic partner params functionality
+    execute <<~SQL
+      UPDATE cbv_applicants
+      SET
+        partner_identifier = case_number,
+        agency_partner_metadata = jsonb_strip_nulls(
+          jsonb_build_object(
+            'first_name',  first_name,
+            'middle_name', middle_name,
+            'last_name',   last_name
+          )
+        )
+    SQL
+
+    # backfill existing partners to use the 'default' which has been case_number. This only needs to run a single time
+    execute <<~SQL
+      UPDATE partner_configs
+      SET partner_identifier_name = 'case_number'
+      WHERE partner_identifier_name IS NULL
+        AND partner_id <> 'mirza'
+    SQL
+  end
+
+  # no down migration since it would be a moot point, this is only additive / updates new column
+end

--- a/app/db/migrate/20260505200001_backfill_partner_identifier_and_metadata.rb
+++ b/app/db/migrate/20260505200001_backfill_partner_identifier_and_metadata.rb
@@ -21,7 +21,6 @@ class BackfillPartnerIdentifierAndMetadata < ActiveRecord::Migration[7.2]
       UPDATE partner_configs
       SET partner_identifier_name = 'case_number'
       WHERE partner_identifier_name IS NULL
-        AND partner_id <> 'mirza'
     SQL
   end
 

--- a/app/db/migrate/20260505200002_drop_legacy_applicant_columns.rb
+++ b/app/db/migrate/20260505200002_drop_legacy_applicant_columns.rb
@@ -1,0 +1,24 @@
+class DropLegacyApplicantColumns < ActiveRecord::Migration[7.2]
+  def up
+    remove_column :cbv_applicants, :case_number
+    remove_column :cbv_applicants, :first_name
+    remove_column :cbv_applicants, :middle_name
+    remove_column :cbv_applicants, :last_name
+  end
+
+  def down
+    add_column :cbv_applicants, :case_number, :string
+    add_column :cbv_applicants, :first_name, :string
+    add_column :cbv_applicants, :middle_name, :string
+    add_column :cbv_applicants, :last_name, :string
+
+    execute <<~SQL
+      UPDATE cbv_applicants
+      SET
+        case_number = partner_identifier,
+        first_name  = agency_partner_metadata ->> 'first_name',
+        middle_name = agency_partner_metadata ->> 'middle_name',
+        last_name   = agency_partner_metadata ->> 'last_name'
+    SQL
+  end
+end

--- a/app/db/schema.rb
+++ b/app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_01_210743) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_05_200002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -24,10 +24,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_01_210743) do
   end
 
   create_table "cbv_applicants", force: :cascade do |t|
-    t.string "case_number"
-    t.string "first_name"
-    t.string "middle_name"
-    t.string "last_name"
     t.string "agency_id_number"
     t.string "client_id_number"
     t.date "snap_application_date"
@@ -39,6 +35,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_01_210743) do
     t.jsonb "income_changes"
     t.date "date_of_birth"
     t.string "doc_id"
+    t.jsonb "agency_partner_metadata", default: {}, null: false
+    t.string "partner_identifier"
+    t.index ["partner_identifier"], name: "index_cbv_applicants_on_partner_identifier"
   end
 
   create_table "cbv_flow_invitations", force: :cascade do |t|
@@ -122,6 +121,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_01_210743) do
     t.datetime "updated_at", null: false
     t.boolean "include_invitation_details_on_weekly_report", default: false, null: false
     t.string "state_name"
+    t.string "partner_identifier_name"
     t.index ["partner_id"], name: "index_partner_configs_on_partner_id", unique: true
   end
 

--- a/app/lib/client_agency_config.rb
+++ b/app/lib/client_agency_config.rb
@@ -146,6 +146,7 @@ class ClientAgencyConfig
       require_applicant_information_on_invitation
       include_invitation_details_on_weekly_report
       state_name
+      partner_identifier_name
     ])
 
     def initialize(partner_config)
@@ -189,6 +190,7 @@ class ClientAgencyConfig
       @include_invitation_details_on_weekly_report = partner_config.respond_to?(:include_invitation_details_on_weekly_report) &&
         partner_config.include_invitation_details_on_weekly_report
       @state_name = partner_config.respond_to?(:state_name) ? partner_config.state_name : nil
+      @partner_identifier_name = partner_config.partner_identifier_name
 
       raise ArgumentError.new("Client Agency missing id") if @id.blank?
       raise ArgumentError.new("Client Agency #{@id} missing required attribute `timezone`") if @timezone.blank?
@@ -196,17 +198,14 @@ class ClientAgencyConfig
       raise ArgumentError.new("Client Agency #{@id} invalid value for pay_income_days.w2") unless VALID_PAY_INCOME_DAYS.include?(@pay_income_days[:w2])
       raise ArgumentError.new("Client Agency #{@id} invalid value for pay_income_days.gig") unless VALID_PAY_INCOME_DAYS.include?(@pay_income_days[:gig])
       raise ArgumentError.new("Client Agency #{@id} missing required attribute `transmission_method`") if @transmission_method.blank?
-    end
-
-    def self.case_number(cbv_flow)
-      cbv_flow.cbv_applicant.case_number.rjust(8, "0")
+      raise ArgumentError.new("Client Agency #{@id} missing required attribute `partner_identifier_name`") if @partner_identifier_name.blank?
     end
 
     def pdf_filename(cbv_flow, time)
       time = time.in_time_zone(timezone)
 
-      padded_case_number = cbv_flow.cbv_applicant.case_number.rjust(8, "0")
-      "CBVPilot_#{padded_case_number}_" \
+      padded_identifier = cbv_flow.cbv_applicant.partner_identifier.to_s.rjust(8, "0")
+      "CBVPilot_#{padded_identifier}_" \
         "#{time.strftime('%Y%m%d')}_" \
         "Conf#{cbv_flow.confirmation_code}"
     end

--- a/app/lib/partner_config_loader.rb
+++ b/app/lib/partner_config_loader.rb
@@ -18,9 +18,10 @@ class PartnerConfigLoader
     weekly_report_enabled weekly_report_recipients weekly_report_variant
     include_invitation_details_on_weekly_report
     transmission_method
+    partner_identifier_name
   ].freeze
 
-  REQUIRED_ATTRS = %w[partner_id name timezone transmission_method pay_income_days_w2 pay_income_days_gig].freeze
+  REQUIRED_ATTRS = %w[partner_id name timezone transmission_method pay_income_days_w2 pay_income_days_gig partner_identifier_name].freeze
 
   # Subdomain prefixes reserved for non-partner infrastructure. A partner
   # claiming one of these would never receive traffic — DNS for the
@@ -77,6 +78,7 @@ class PartnerConfigLoader
     validate_domain
     validate_transmission_configs
     validate_application_attributes
+    validate_partner_identifier_name
     validate_translations
 
     self
@@ -266,6 +268,18 @@ class PartnerConfigLoader
         @errors << "application_attributes[#{i}]: duplicate name '#{attr[:name]}'"
       end
       names << attr[:name]
+    end
+  end
+
+  def validate_partner_identifier_name
+    name = @data[:partner_identifier_name]
+    return if name.blank?
+    attrs = @data[:application_attributes] || []
+    matching = attrs.find { |a| a[:name].to_s == name.to_s }
+    if matching.nil?
+      @errors << "partner_identifier_name '#{name}' must be defined as an entry in application_attributes"
+    elsif !matching[:required]
+      @errors << "partner_identifier_name '#{name}' must reference an application_attribute with required: true"
     end
   end
 

--- a/app/lib/tasks/invitation.rake
+++ b/app/lib/tasks/invitation.rake
@@ -12,12 +12,30 @@ namespace :invitation do
       )
 
       user.update(is_service_account: true)
+      agency = ClientAgencyConfig.instance[client_agency_id]
+
+      # to use this rake to create an example invitation for another partner, this sample metadata would need to be expanded to include the values required by that partner
+      sample_metadata = {
+        "first_name" => "Joe",
+        "last_name" => "Schmoe",
+        "date_of_birth" => Date.new(1990, 1, 1)
+      }
+      applicant_attrs = {
+        client_agency_id: client_agency_id,
+        partner_identifier: rand(1000..9999).to_s
+      }
+      # Only carry sample fields when the agency has them configured. Real
+      # columns and partner-defined attributes alike are routed correctly.
+      sample_metadata.each do |key, value|
+        applicant_attrs[key.to_sym] = value if agency&.applicant_attributes&.key?(key)
+      end
+
       invite = CbvFlowInvitation.new({
         user: user,
         client_agency_id: client_agency_id,
         language: "en",
         email_address: user.email,
-        cbv_applicant_attributes: { first_name: "Joe", last_name: "Schmoe", client_agency_id: client_agency_id, case_number: rand(1000..9999).to_s }
+        cbv_applicant_attributes: applicant_attrs
       })
       invite.save!
       log.info "Invite link created successfully! 🎉"

--- a/app/lib/tasks/partner.rake
+++ b/app/lib/tasks/partner.rake
@@ -42,5 +42,4 @@ namespace :partner do
       MatchAgencyNamesJob.perform_now(cbv_flow.id)
     end
   end
-
 end

--- a/app/lib/tasks/partner.rake
+++ b/app/lib/tasks/partner.rake
@@ -43,10 +43,4 @@ namespace :partner do
     end
   end
 
-  desc "redact case numbers for a partner"
-  task :redact_case_numbers, [ :partner_id ] => :environment do |_t, args|
-    partner_id = args.fetch(:partner_id)
-    Rails.logger.info "Redacting case-numbers for #{partner_id}..."
-    DataRetentionService.redact_case_numbers_by_agency(partner_id)
-  end
 end

--- a/app/spec/controllers/api/invitations_controller_spec.rb
+++ b/app/spec/controllers/api/invitations_controller_spec.rb
@@ -136,10 +136,10 @@ RSpec.describe Api::InvitationsController do
         valid_params
       end
 
-      it "returns unprocessable entity with structured error response" do
+      it "returns bad request with structured error response when a required attribute is missing" do
         post :create, params: invalid_params
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:bad_request)
         parsed_response = JSON.parse(response.body)
 
         # Check for structured error response
@@ -150,7 +150,7 @@ RSpec.describe Api::InvitationsController do
         error_fields = parsed_response["errors"].map { |e| e["field"] }
 
         expect(error_fields).not_to include("cbv_applicant")
-        expect(error_fields).to include("cbv_applicant.first_name")
+        expect(error_fields).to include("agency_partner_metadata.first_name")
       end
     end
 

--- a/app/spec/controllers/cbv/applicant_informations_controller_spec.rb
+++ b/app/spec/controllers/cbv/applicant_informations_controller_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe Cbv::ApplicantInformationsController, type: :controller do
             cbv_applicant: {
               first_name: "Daph", # required
               middle_name: "",
-              last_name: "", # required
-              date_of_birth: { month: "", day: "", year: "" }, # required
-              case_number: "" # required
+              last_name: nil, # required, nil
+              date_of_birth: { month: "", day: "", year: "" }, # required, parses to nil
+              case_number: nil # required, nil
             }
           }
         }
@@ -104,7 +104,7 @@ RSpec.describe Cbv::ApplicantInformationsController, type: :controller do
             cbv_applicant: {
               first_name: "Daph",
               middle_name: "",
-              last_name: "", # required but missing
+              last_name: nil, # required but missing (nil triggers validation)
               date_of_birth: {
                 month: "03",
                 day: "19",

--- a/app/spec/factories/cbv_applicant.rb
+++ b/app/spec/factories/cbv_applicant.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :cbv_applicant do
     client_agency_id { "sandbox" }
+    case_number { 8.times.map { rand(10) }.join }
     first_name { "Jane" }
     middle_name { "Sue" }
     last_name { "Doe" }
@@ -21,11 +22,6 @@ FactoryBot.define do
       first_name { nil }
       middle_name { nil }
       last_name { nil }
-
-      case_number do
-        # TODO: Determine actual AZ DES case number format.
-        8.times.map { rand(10) }.join
-      end
 
       income_changes do
         [
@@ -62,11 +58,6 @@ FactoryBot.define do
       middle_name { nil }
       last_name { nil }
 
-      case_number do
-        # TODO: Determine actual PA DHS case number format.
-        8.times.map { rand(10) }.join
-      end
-
       income_changes do
         [
           {
@@ -98,12 +89,6 @@ FactoryBot.define do
 
     trait :la_ldh do
       client_agency_id { "la_ldh" }
-
-      case_number do
-        # TODO: Determine actual LA LDH case number format.
-        8.times.map { rand(10) }.join
-      end
-
       date_of_birth { Date.new(2000, 1, 1) }
       doc_id { "%08d" % rand(100_000_000) }
     end

--- a/app/spec/factories/partner_config.rb
+++ b/app/spec/factories/partner_config.rb
@@ -22,6 +22,7 @@ FactoryBot.define do
     weekly_report_variant { "invitations" }
     invitation_valid_days_default { 14 }
     report_customization_show_earnings_list { true }
+    partner_identifier_name { "case_number" }
 
     trait :az_des do
       partner_id { "az_des" }

--- a/app/spec/lib/client_agency_config_spec.rb
+++ b/app/spec/lib/client_agency_config_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe ClientAgencyConfig do
       transmission_method: 'shared_email',
       argyle_environment: 'foo',
       pay_income_days_w2: 90,
-      pay_income_days_gig: 182
+      pay_income_days_gig: 182,
+      partner_identifier_name: 'first_name'
     )
   end
 

--- a/app/spec/lib/partner_config_loader_spec.rb
+++ b/app/spec/lib/partner_config_loader_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe PartnerConfigLoader do
       "report_customization_show_earnings_list" => true,
       "weekly_report_enabled" => false,
       "transmission_method" => "shared_email",
+      "partner_identifier_name" => "case_number",
       "transmission_configs" => [
         { "key" => "email", "encrypted" => false, "value" => "reports@test.example.com" }
       ],

--- a/app/spec/mailers/weekly_report_mailer_spec.rb
+++ b/app/spec/mailers/weekly_report_mailer_spec.rb
@@ -129,7 +129,8 @@ RSpec.describe WeeklyReportMailer, type: :mailer do
             "report_variant" => "invitations"
           },
           include_invitation_details_on_weekly_report: true,
-          applicant_attributes: ClientAgencyConfig.instance["az_des"].applicant_attributes
+          applicant_attributes: ClientAgencyConfig.instance["az_des"].applicant_attributes,
+          partner_identifier_name: "case_number"
         )
         allow_any_instance_of(WeeklyReportMailer).to receive(:client_agency_config).and_return({
           "az_des" => az_config
@@ -199,7 +200,8 @@ RSpec.describe WeeklyReportMailer, type: :mailer do
             "report_variant" => "invitations"
           },
           include_invitation_details_on_weekly_report: true,
-          applicant_attributes: ClientAgencyConfig.instance["pa_dhs"].applicant_attributes
+          applicant_attributes: ClientAgencyConfig.instance["pa_dhs"].applicant_attributes,
+          partner_identifier_name: "case_number"
         )
         allow_any_instance_of(WeeklyReportMailer).to receive(:client_agency_config).and_return({
           "pa_dhs" => pa_config

--- a/app/spec/models/cbv_applicant_spec.rb
+++ b/app/spec/models/cbv_applicant_spec.rb
@@ -9,24 +9,30 @@ RSpec.describe CbvApplicant, type: :model do
     end
   end
 
-  describe "#has_applicant_attribute_missing?" do
+  describe "#missing_required_attributes" do
     before do
+      # Include a subset of attributes for testing, mark first_name as required for test purposes
       allow_any_instance_of(ClientAgencyConfig::ClientAgency).to receive(:applicant_attributes).and_return(
-        { first_name: "required" }
+        {
+          "case_number" => "required",
+          "first_name" => "required",
+          "middle_name" => "",
+          "last_name" => ""
+        }
       )
     end
 
     let(:cbv_applicant) { create(:cbv_applicant, first_name: nil) }
-    it "returns true if a field missing" do
+    it "includes the missing required attribute names" do
       cbv_applicant.set_applicant_attributes
       expect(cbv_applicant.required_applicant_attributes).to be_present
-      expect(cbv_applicant.has_applicant_attribute_missing?).to eq(true)
+      expect(cbv_applicant.missing_required_attributes).to include(:first_name)
     end
 
-    it "returns false if a field not missing" do
+    it "returns an empty array when all required attributes are present" do
       cbv_applicant.set_applicant_attributes
       cbv_applicant.first_name = "Dean Venture"
-      expect(cbv_applicant.has_applicant_attribute_missing?).to eq(false)
+      expect(cbv_applicant.missing_required_attributes).to be_empty
     end
   end
 
@@ -34,7 +40,7 @@ RSpec.describe CbvApplicant, type: :model do
     let(:date_of_birth) { build(:cbv_applicant).date_of_birth }
 
     it "returns an array of symbols containing the missing field keys" do
-      cbv_applicant_without_case_number = build(:cbv_applicant, :sandbox, middle_name: nil)
+      cbv_applicant_without_case_number = build(:cbv_applicant, :sandbox, middle_name: nil, case_number: nil)
       cbv_applicant_without_case_number.set_applicant_attributes
       expect(cbv_applicant_without_case_number.required_applicant_attributes).to be_present
       expect(cbv_applicant_without_case_number.case_number).to be_nil
@@ -256,8 +262,11 @@ RSpec.describe CbvApplicant, type: :model do
         before do
           allow_any_instance_of(ClientAgencyConfig::ClientAgency).to receive(:applicant_attributes).and_return(
             {
-              first_name: { "required" => true },
-              date_of_birth: { "required" => true, "type" => "date" }
+              "case_number" => { "required" => false },
+              "first_name" => { "required" => true },
+              "middle_name" => { "required" => false },
+              "last_name" => { "required" => false },
+              "date_of_birth" => { "required" => true, "type" => "date" }
             }
           )
         end

--- a/app/spec/models/cbv_flow_invitation_spec.rb
+++ b/app/spec/models/cbv_flow_invitation_spec.rb
@@ -132,7 +132,8 @@ RSpec.describe CbvFlowInvitation, type: :model do
     let(:agency_time_zone) { "America/New_York" }
 
     let(:partner_app_attributes) do
-      PartnerApplicationAttribute.where(partner_config: client_agency_id).each_with_object({}) do |attr, h|
+      partner = PartnerConfig.find_by(partner_id: client_agency_id)
+      PartnerApplicationAttribute.where(partner_config: partner).each_with_object({}) do |attr, h|
         h[attr.name] = attr
       end.with_indifferent_access
     end
@@ -142,7 +143,8 @@ RSpec.describe CbvFlowInvitation, type: :model do
         invitation_valid_days: invitation_valid_days,
         applicant_attributes: partner_app_attributes,
         require_applicant_information_on_invitation: true,
-        timezone: "America/New_York"
+        timezone: "America/New_York",
+        partner_identifier_name: "case_number"
       )
     end
 
@@ -216,7 +218,8 @@ RSpec.describe CbvFlowInvitation, type: :model do
     let(:invitation_sent_at) { Time.use_zone(agency_time_zone) { Time.zone.local(2024, 8,  1, 12, 0, 0) } }
 
     let(:partner_app_attributes) do
-      PartnerApplicationAttribute.where(partner_config: client_agency_id).each_with_object({}) do |attr, h|
+      partner = PartnerConfig.find_by(partner_id: client_agency_id)
+      PartnerApplicationAttribute.where(partner_config: partner).each_with_object({}) do |attr, h|
         h[attr.name] = attr
       end.with_indifferent_access
     end
@@ -226,7 +229,8 @@ RSpec.describe CbvFlowInvitation, type: :model do
         invitation_valid_days: invitation_valid_days,
         applicant_attributes: partner_app_attributes,
         require_applicant_information_on_invitation: true,
-        timezone: "America/New_York"
+        timezone: "America/New_York",
+        partner_identifier_name: "case_number"
       )
     end
 

--- a/app/spec/services/cbv_invitation_service_spec.rb
+++ b/app/spec/services/cbv_invitation_service_spec.rb
@@ -24,11 +24,9 @@ RSpec.describe CbvInvitationService, type: :service do
         )
 
         invitation = CbvFlowInvitation.last
-        expect(invitation).to have_attributes(
-          user: current_user,
-          cbv_applicant: have_attributes(
-            case_number: cbv_flow_invitation_params[:case_number]
-          )
+        expect(invitation.user).to eq(current_user)
+        expect(invitation.cbv_applicant.case_number).to eq(
+          cbv_flow_invitation_params[:cbv_applicant_attributes][:case_number]
         )
       end
 
@@ -71,11 +69,9 @@ RSpec.describe CbvInvitationService, type: :service do
         )
 
         invitation = CbvFlowInvitation.last
-        expect(invitation).to have_attributes(
-          user: current_user,
-          cbv_applicant: have_attributes(
-            case_number: cbv_flow_invitation_params[:case_number]
-          )
+        expect(invitation.user).to eq(current_user)
+        expect(invitation.cbv_applicant.case_number).to eq(
+          cbv_flow_invitation_params[:cbv_applicant_attributes][:case_number]
         )
       end
 

--- a/app/spec/services/data_retention_service_spec.rb
+++ b/app/spec/services/data_retention_service_spec.rb
@@ -537,22 +537,30 @@ RSpec.describe DataRetentionService do
     end
   end
 
-  describe ".manually_redact_by_case_number!" do
-    let(:cbv_flow_invitation) { create(:cbv_flow_invitation, cbv_applicant_attributes: { case_number: "DELETEME001" }) }
+  describe ".manually_redact_by_partner_identifier!" do
+    let(:cbv_flow_invitation) do
+      create(:cbv_flow_invitation, client_agency_id: "sandbox",
+        cbv_applicant_attributes: { client_agency_id: "sandbox", case_number: "DELETEME001" })
+    end
     let!(:cbv_flow) { CbvFlow.create_from_invitation(cbv_flow_invitation, "test_device_id") }
     let!(:second_cbv_flow) { CbvFlow.create_from_invitation(cbv_flow_invitation, "test_device_id_2") }
     let!(:payroll_account) { create(:payroll_account, cbv_flow: second_cbv_flow) }
 
-    it "redacts the invitation and all flow objects" do
-      DataRetentionService.manually_redact_by_case_number!("DELETEME001")
+    it "redacts the invitation, all flow objects, and the metadata jsonb keys flagged redactable" do
+      DataRetentionService.manually_redact_by_partner_identifier!("sandbox", "DELETEME001")
 
       expect(cbv_flow.reload).to have_attributes(
         redacted_at: within(1.second).of(Time.now)
       )
-      expect(cbv_flow.cbv_applicant.reload).to have_attributes(
-        first_name: "REDACTED",
-        redacted_at: within(1.second).of(Time.now)
-      )
+
+      applicant = cbv_flow.cbv_applicant.reload
+      expect(applicant.redacted_at).to be_within(1.second).of(Time.now)
+
+      expect(applicant.first_name).to eq("REDACTED")
+      expect(applicant.agency_partner_metadata).to include("first_name" => "REDACTED")
+
+      expect(applicant.partner_identifier).to eq("DELETEME001")
+
       expect(second_cbv_flow.reload).to have_attributes(
         redacted_at: within(1.second).of(Time.now)
       )
@@ -564,6 +572,52 @@ RSpec.describe DataRetentionService do
       )
     end
 
+    it "redacts every matching applicant when the same partner_identifier value is reused within an agency" do
+      duplicate_invitation = create(:cbv_flow_invitation, client_agency_id: "sandbox",
+        cbv_applicant_attributes: { client_agency_id: "sandbox", case_number: "DELETEME001" })
+      duplicate_flow = CbvFlow.create_from_invitation(duplicate_invitation, "another_device")
+
+      DataRetentionService.manually_redact_by_partner_identifier!("sandbox", "DELETEME001")
+
+      expect(duplicate_flow.reload.redacted_at).to be_within(1.second).of(Time.now)
+      expect(duplicate_flow.cbv_applicant.reload.redacted_at).to be_within(1.second).of(Time.now)
+    end
+
+    it "does not touch applicants with the same partner_identifier in a different agency" do
+      other_agency_invitation = create(:cbv_flow_invitation, :az_des,
+        cbv_applicant_attributes: { client_agency_id: "az_des", case_number: "DELETEME001",
+                                     first_name: "Other", last_name: "Person" })
+      other_flow = CbvFlow.create_from_invitation(other_agency_invitation, "az_device")
+
+      DataRetentionService.manually_redact_by_partner_identifier!("sandbox", "DELETEME001")
+
+      expect(other_flow.reload.redacted_at).to be_nil
+      expect(other_flow.cbv_applicant.reload.redacted_at).to be_nil
+      expect(other_flow.cbv_applicant.partner_identifier).to eq("DELETEME001")
+    end
+
+    it "raises when no applicant matches" do
+      expect {
+        DataRetentionService.manually_redact_by_partner_identifier!("sandbox", "DOES_NOT_EXIST")
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    context "when the agency's partner_identifier_name attribute is also flagged redactable" do
+      before do
+        sandbox_config = PartnerConfig.find_by(partner_id: "sandbox")
+        PartnerApplicationAttribute
+          .where(partner_config: sandbox_config, name: "case_number")
+          .update_all(redactable: true, redact_type: "string")
+        ClientAgencyConfig.reset!
+      end
+
+      it "redacts the partner_identifier column" do
+        DataRetentionService.manually_redact_by_partner_identifier!("sandbox", "DELETEME001")
+
+        expect(cbv_flow.cbv_applicant.reload.partner_identifier).to eq("REDACTED")
+      end
+    end
+
     context "when a flow has an argyle_user_id" do
       before do
         second_cbv_flow.update!(argyle_user_id: "argyle_manual_123", client_agency_id: "sandbox")
@@ -571,7 +625,7 @@ RSpec.describe DataRetentionService do
 
       it "deletes the argyle user" do
         expect_any_instance_of(DataRetentionService).to receive(:delete_argyle_user).with("sandbox", "argyle_manual_123")
-        DataRetentionService.manually_redact_by_case_number!("DELETEME001")
+        DataRetentionService.manually_redact_by_partner_identifier!("sandbox", "DELETEME001")
       end
     end
   end
@@ -606,26 +660,6 @@ RSpec.describe DataRetentionService do
         expect { service.send(:redact_cbv_flow, cbv_flow) }.to raise_error(StandardError)
         expect(cbv_flow.reload.redacted_at).to be_nil
       end
-    end
-  end
-
-  describe ".redact_case_numbers_by_agency" do
-    let(:agency_to_redact) { "sandbox" }
-    let!(:cbv_flow_invitation) { create(:cbv_flow_invitation, cbv_applicant_attributes: { case_number: "DELETEME001", client_agency_id: agency_to_redact }) }
-    let!(:cbv_flow_invitation2) { create(:cbv_flow_invitation, cbv_applicant_attributes: { case_number: "DELETEME002", client_agency_id: agency_to_redact }) }
-    let!(:cbv_flow) { CbvFlow.create_from_invitation(cbv_flow_invitation, "test_device_id") }
-    let!(:cbv_flow2) { CbvFlow.create_from_invitation(cbv_flow_invitation2, "test_device_id_2") }
-
-    it "redacts all case numbers for a given agency" do
-      DataRetentionService.redact_case_numbers_by_agency(agency_to_redact)
-      expect(cbv_flow.cbv_applicant.reload).to have_attributes(
-        case_number: "REDACTED",
-        redacted_at: within(1.second).of(Time.now)
-      )
-      expect(cbv_flow2.cbv_applicant.reload).to have_attributes(
-        case_number: "REDACTED",
-        redacted_at: within(1.second).of(Time.now)
-      )
     end
   end
 end

--- a/wc.yml
+++ b/wc.yml
@@ -22,6 +22,7 @@ weekly_report_recipients: west_carolina@example.org
 weekly_report_variant: invitations
 include_invitation_details_on_weekly_report: true
 transmission_method: sftp
+partner_identifier_name: case_number
 transmission_configs:
 - key: user
   encrypted: false


### PR DESCRIPTION
## Summary
As part of getting mirza to work properly this refactored how we handle dynamic partner metadata, and abstracted the partner identifier and made it configurable.

## Type of Change
Check all that apply.
- [ ] Bug
- [ ] Feature
- [X] Refactor
- [x] Documentation update

## Changes
* add partner identifier name to partner_config, run migration to backfill
* add jsonb metadata column for applicant for custom partner properties
* remove various partner-specific columns from cbv_applicant
* dynamic logic to properly populate top level columns or create jsonb metadata properties
* update all tests for affected functionality
* 

## Checklist
- [x] Tests added/updated (if needed)
- [x] Docs updated (if needed)

## Notes for Reviewers
[if anything need special attention, note it here]
