### PR TITLE
Cle/pf 710 metrics

### DIFF
--- a/app/app/controllers/api/invitations_controller.rb
+++ b/app/app/controllers/api/invitations_controller.rb
@@ -4,6 +4,17 @@ class Api::InvitationsController < ApplicationController
 
   LEGACY_CUSTOM_ATTRIBUTES_PARAM = :agency_partner_metadata
   CUSTOM_ATTRIBUTES_PARAM = :custom_attributes
+  METRICS_ATTRIBUTES_PARAM = :metrics_attributes
+
+  # return useful information if there is a malformed invitation api body
+  rescue_from ActionDispatch::Http::Parameters::ParseError do |exception|
+    underlying = exception.cause&.message || exception.message
+    render json: {
+      errors: [
+        { field: "body", message: "Request body is not valid JSON: #{underlying}" }
+      ]
+    }, status: :bad_request
+  end
 
   before_action :authenticate
 
@@ -21,7 +32,7 @@ class Api::InvitationsController < ApplicationController
     end
 
     cbv_flow_invitation = CbvInvitationService.new(event_logger)
-      .invite(cbv_flow_invitation_params, @current_user, delivery_method: nil)
+      .invite(cbv_flow_invitation_params, @current_user, delivery_method: nil, metrics_attributes: metrics_attributes_hash)
 
     errors = cbv_flow_invitation.errors
     if errors.any?
@@ -47,7 +58,7 @@ class Api::InvitationsController < ApplicationController
     client_agency_id = @current_user.client_agency_id
 
     # Top-level invitation params (language, email, expiration).
-    permitted = params.without(:client_agency_id, CUSTOM_ATTRIBUTES_PARAM, LEGACY_CUSTOM_ATTRIBUTES_PARAM).permit(
+    permitted = params.without(:client_agency_id, CUSTOM_ATTRIBUTES_PARAM, LEGACY_CUSTOM_ATTRIBUTES_PARAM, METRICS_ATTRIBUTES_PARAM).permit(
       :language, :email_address, :user_id, :expiration_date, :expiration_days
     )
 
@@ -100,6 +111,19 @@ class Api::InvitationsController < ApplicationController
     raw = params[CUSTOM_ATTRIBUTES_PARAM].presence || params[LEGACY_CUSTOM_ATTRIBUTES_PARAM]
     return {} if raw.blank?
     raw.respond_to?(:to_unsafe_h) ? raw.to_unsafe_h : raw.to_h
+  end
+
+  # all metrics attributes are lowercased and prefixed with 'x-' (if not already present) to prevent possible key collision
+  def metrics_attributes_hash
+    raw = params[METRICS_ATTRIBUTES_PARAM]
+    return {} if raw.blank?
+    hash = raw.respond_to?(:to_unsafe_h) ? raw.to_unsafe_h : (raw.is_a?(Hash) ? raw.to_h : {})
+    hash.each_with_object({}) do |(k, v), result|
+      next if k.blank?
+      normalized = k.to_s.downcase
+      normalized = "x-#{normalized}" unless normalized.start_with?("x-")
+      result[normalized] = v
+    end
   end
 
   def missing_required_errors(missing)

--- a/app/app/controllers/api/invitations_controller.rb
+++ b/app/app/controllers/api/invitations_controller.rb
@@ -19,13 +19,6 @@ class Api::InvitationsController < ApplicationController
   before_action :authenticate
 
   def create
-    if params[CUSTOM_ATTRIBUTES_PARAM].present? && params[LEGACY_CUSTOM_ATTRIBUTES_PARAM].present?
-      return render json: {
-        errors: [ { field: CUSTOM_ATTRIBUTES_PARAM.to_s,
-                    message: "Provide either #{CUSTOM_ATTRIBUTES_PARAM} or #{LEGACY_CUSTOM_ATTRIBUTES_PARAM}, but not both." } ]
-      }, status: :bad_request
-    end
-
     missing = missing_required_custom_attributes_keys
     if missing.any?
       return render json: missing_required_errors(missing), status: :bad_request
@@ -106,7 +99,7 @@ class Api::InvitationsController < ApplicationController
     required_attrs.keys.reject { |name| incoming[name].present? }
   end
 
-  # allows either custom_attributes or agency_partner_metadata to allow for backwards compatibility
+  # allow both custom_attributes and agency_partner_metadata to account for legacy partners
   def unsafe_custom_attributes_hash
     raw = params[CUSTOM_ATTRIBUTES_PARAM].presence || params[LEGACY_CUSTOM_ATTRIBUTES_PARAM]
     return {} if raw.blank?

--- a/app/app/controllers/api/invitations_controller.rb
+++ b/app/app/controllers/api/invitations_controller.rb
@@ -2,10 +2,20 @@ class Api::InvitationsController < ApplicationController
   skip_forgery_protection
   wrap_parameters false
 
+  LEGACY_CUSTOM_ATTRIBUTES_PARAM = :agency_partner_metadata
+  CUSTOM_ATTRIBUTES_PARAM = :custom_attributes
+
   before_action :authenticate
 
   def create
-    missing = missing_required_metadata_keys
+    if params[CUSTOM_ATTRIBUTES_PARAM].present? && params[LEGACY_CUSTOM_ATTRIBUTES_PARAM].present?
+      return render json: {
+        errors: [ { field: CUSTOM_ATTRIBUTES_PARAM.to_s,
+                    message: "Provide either #{CUSTOM_ATTRIBUTES_PARAM} or #{LEGACY_CUSTOM_ATTRIBUTES_PARAM}, but not both." } ]
+      }, status: :bad_request
+    end
+
+    missing = missing_required_custom_attributes_keys
     if missing.any?
       return render json: missing_required_errors(missing), status: :bad_request
     end
@@ -37,22 +47,21 @@ class Api::InvitationsController < ApplicationController
     client_agency_id = @current_user.client_agency_id
 
     # Top-level invitation params (language, email, expiration).
-    permitted = params.without(:client_agency_id, :agency_partner_metadata).permit(
+    permitted = params.without(:client_agency_id, CUSTOM_ATTRIBUTES_PARAM, LEGACY_CUSTOM_ATTRIBUTES_PARAM).permit(
       :language, :email_address, :user_id, :expiration_date, :expiration_days
     )
 
-    # Split the incoming agency_partner_metadata hash by destination on
-    # cbv_applicants:
+    # Split the incoming custom_attributes hash by destination on cbv_applicants:
     #   - The key matching `partner_identifier_name` → partner_identifier column.
     #   - Keys that match real columns (date_of_birth, snap_application_date, etc.)
     #     → assigned directly to those columns.
-    #   - Everything else → packed into the agency_partner_metadata jsonb.
-    incoming = unsafe_metadata_hash
+    #   - Everything else → packed into the custom_attributes jsonb.
+    incoming = unsafe_custom_attributes_hash
     identifier_name = partner_config.partner_identifier_name
     real_columns = CbvApplicant.column_names
 
     partner_identifier_value = nil
-    metadata = {}
+    custom_attributes = {}
     direct_column_assignments = {}
 
     partner_config.applicant_attributes.keys.each do |name|
@@ -63,14 +72,14 @@ class Api::InvitationsController < ApplicationController
       elsif real_columns.include?(key)
         direct_column_assignments[key.to_sym] = value
       else
-        metadata[key] = value
+        custom_attributes[key] = value
       end
     end
 
     cbv_applicant_attrs = {
       client_agency_id: client_agency_id,
       partner_identifier: partner_identifier_value,
-      agency_partner_metadata: metadata
+      custom_attributes: custom_attributes
     }.merge(direct_column_assignments)
 
     permitted.deep_merge!(
@@ -80,15 +89,15 @@ class Api::InvitationsController < ApplicationController
     )
   end
 
-  def missing_required_metadata_keys
-    incoming = unsafe_metadata_hash
+  def missing_required_custom_attributes_keys
+    incoming = unsafe_custom_attributes_hash
     required_attrs = partner_config.applicant_attributes.select { |_name, attr| attr.required }
     required_attrs.keys.reject { |name| incoming[name].present? }
   end
 
-  # create output matching the expected data, drop anything unexpected.
-  def unsafe_metadata_hash
-    raw = params[:agency_partner_metadata]
+  # allows either custom_attributes or agency_partner_metadata to allow for backwards compatibility
+  def unsafe_custom_attributes_hash
+    raw = params[CUSTOM_ATTRIBUTES_PARAM].presence || params[LEGACY_CUSTOM_ATTRIBUTES_PARAM]
     return {} if raw.blank?
     raw.respond_to?(:to_unsafe_h) ? raw.to_unsafe_h : raw.to_h
   end
@@ -96,7 +105,7 @@ class Api::InvitationsController < ApplicationController
   def missing_required_errors(missing)
     {
       errors: missing.map do |name|
-        { field: "agency_partner_metadata.#{name}", message: "is required" }
+        { field: "#{CUSTOM_ATTRIBUTES_PARAM}.#{name}", message: "is required" }
       end
     }
   end
@@ -110,7 +119,7 @@ class Api::InvitationsController < ApplicationController
   def errors_to_json(errors)
     # Generates a Hash of attribute => error_message and translates the
     # internal names of objects (cbv_applicant) to the external names
-    # (agency_partner_metadata)
+    # (custom_attributes).
     error_messages = errors.map do |error|
       next if error.attribute == :cbv_applicant
 
@@ -119,7 +128,7 @@ class Api::InvitationsController < ApplicationController
       case error
       when ActiveModel::NestedError
         prefix, attribute_name = error.attribute.to_s.split(".")
-        prefix = "agency_partner_metadata" if prefix == "cbv_applicant"
+        prefix = CUSTOM_ATTRIBUTES_PARAM.to_s if prefix == "cbv_applicant"
 
         { field: "#{prefix}.#{attribute_name}", message: error_message }
       else

--- a/app/app/controllers/api/invitations_controller.rb
+++ b/app/app/controllers/api/invitations_controller.rb
@@ -2,10 +2,6 @@ class Api::InvitationsController < ApplicationController
   skip_forgery_protection
   wrap_parameters false
 
-  LEGACY_CUSTOM_ATTRIBUTES_PARAM = :agency_partner_metadata
-  CUSTOM_ATTRIBUTES_PARAM = :custom_attributes
-  METRICS_ATTRIBUTES_PARAM = :metrics_attributes
-
   # return useful information if there is a malformed invitation api body
   rescue_from ActionDispatch::Http::Parameters::ParseError do |exception|
     underlying = exception.cause&.message || exception.message
@@ -51,7 +47,7 @@ class Api::InvitationsController < ApplicationController
     client_agency_id = @current_user.client_agency_id
 
     # Top-level invitation params (language, email, expiration).
-    permitted = params.without(:client_agency_id, CUSTOM_ATTRIBUTES_PARAM, LEGACY_CUSTOM_ATTRIBUTES_PARAM, METRICS_ATTRIBUTES_PARAM).permit(
+    permitted = params.without(:client_agency_id, :custom_attributes, :agency_partner_metadata, :metrics_attributes).permit(
       :language, :email_address, :user_id, :expiration_date, :expiration_days
     )
 
@@ -101,14 +97,14 @@ class Api::InvitationsController < ApplicationController
 
   # allow both custom_attributes and agency_partner_metadata to account for legacy partners
   def unsafe_custom_attributes_hash
-    raw = params[CUSTOM_ATTRIBUTES_PARAM].presence || params[LEGACY_CUSTOM_ATTRIBUTES_PARAM]
+    raw = params[:custom_attributes].presence || params[:agency_partner_metadata]
     return {} if raw.blank?
     raw.respond_to?(:to_unsafe_h) ? raw.to_unsafe_h : raw.to_h
   end
 
   # all metrics attributes are lowercased and prefixed with 'x-' (if not already present) to prevent possible key collision
   def metrics_attributes_hash
-    raw = params[METRICS_ATTRIBUTES_PARAM]
+    raw = params[:metrics_attributes]
     return {} if raw.blank?
     hash = raw.respond_to?(:to_unsafe_h) ? raw.to_unsafe_h : (raw.is_a?(Hash) ? raw.to_h : {})
     hash.each_with_object({}) do |(k, v), result|
@@ -122,7 +118,7 @@ class Api::InvitationsController < ApplicationController
   def missing_required_errors(missing)
     {
       errors: missing.map do |name|
-        { field: "#{CUSTOM_ATTRIBUTES_PARAM}.#{name}", message: "is required" }
+        { field: "#{:custom_attributes}.#{name}", message: "is required" }
       end
     }
   end
@@ -145,7 +141,7 @@ class Api::InvitationsController < ApplicationController
       case error
       when ActiveModel::NestedError
         prefix, attribute_name = error.attribute.to_s.split(".")
-        prefix = CUSTOM_ATTRIBUTES_PARAM.to_s if prefix == "cbv_applicant"
+        prefix = :custom_attributes.to_s if prefix == "cbv_applicant"
 
         { field: "#{prefix}.#{attribute_name}", message: error_message }
       else

--- a/app/app/controllers/cbv/preview_controller.rb
+++ b/app/app/controllers/cbv/preview_controller.rb
@@ -175,7 +175,7 @@ class Cbv::PreviewController < ApplicationController
     cbv_applicant = CbvApplicant.create!(
       client_agency_id: client_agency_id,
       partner_identifier: "PREVIEW123",
-      agency_partner_metadata: { "first_name" => "Preview", "last_name" => "User" },
+      custom_attributes: { "first_name" => "Preview", "last_name" => "User" },
       snap_application_date: Date.current
     )
 

--- a/app/app/models/cbv_applicant.rb
+++ b/app/app/models/cbv_applicant.rb
@@ -10,7 +10,7 @@ class CbvApplicant < ApplicationRecord
     agency.applicant_attributes.keys.map(&:to_sym)
   end
 
-  def self.build_agency_partner_metadata(client_agency_id, &value_provider)
+  def self.build_custom_attributes(client_agency_id, &value_provider)
     valid_attributes_for_agency(client_agency_id).each_with_object({}) do |attr, hash|
       hash[attr.to_s] = value_provider.call(attr)
     end
@@ -47,7 +47,7 @@ class CbvApplicant < ApplicationRecord
   def redact!(fields = nil)
     fields_to_redact = fields || redactable_fields_from_config
 
-    if fields_to_redact.blank? && partner_identifier_redactable? == false && agency_partner_metadata.blank?
+    if fields_to_redact.blank? && partner_identifier_redactable? == false && custom_attributes.blank?
       raise "No fields to redact for #{client_agency_id}"
     end
 
@@ -218,13 +218,13 @@ class CbvApplicant < ApplicationRecord
 
   # Read a partner-defined applicant attribute. The value lives either in the
   # `partner_identifier` column (if `name` matches the agency's
-  # `partner_identifier_name`) or in the `agency_partner_metadata` jsonb.
+  # `partner_identifier_name`) or in the `custom_attributes` jsonb.
   # Real ActiveRecord columns (e.g. `snap_application_date`) take precedence
   # via the `super` chain in method_missing.
   def read_applicant_attribute(name)
     name = name.to_s
     return partner_identifier if name == agency_config&.partner_identifier_name.to_s
-    (agency_partner_metadata || {})[name]
+    (custom_attributes || {})[name]
   end
 
   def write_applicant_attribute(name, value)
@@ -232,7 +232,7 @@ class CbvApplicant < ApplicationRecord
     if name == agency_config&.partner_identifier_name.to_s
       self.partner_identifier = value
     else
-      self.agency_partner_metadata = (agency_partner_metadata || {}).merge(name => value)
+      self.custom_attributes = (custom_attributes || {}).merge(name => value)
     end
     value
   end

--- a/app/app/services/cbv_flow_to_json.rb
+++ b/app/app/services/cbv_flow_to_json.rb
@@ -64,12 +64,12 @@ class CbvFlowToJson
   end
 
   def build_client_information
-    # get all configured agency partner metadata properties
-    agency_partner_metadata = CbvApplicant.build_agency_partner_metadata(@current_agency.id) do |attr|
+    # get all configured agency custom attribute properties
+    custom_attributes = CbvApplicant.build_custom_attributes(@current_agency.id) do |attr|
       @cbv_flow.cbv_applicant.public_send(attr)
     end
 
-    agency_partner_metadata.merge(
+    custom_attributes.merge(
       additional_jobs_to_report: @cbv_flow.has_other_jobs
     )
   end

--- a/app/app/services/cbv_invitation_service.rb
+++ b/app/app/services/cbv_invitation_service.rb
@@ -3,7 +3,7 @@ class CbvInvitationService
     @event_logger = event_logger
   end
 
-  def invite(cbv_flow_invitation_params, current_user, delivery_method: :email)
+  def invite(cbv_flow_invitation_params, current_user, delivery_method: :email, metrics_attributes: {})
     cbv_flow_invitation_params[:user] = current_user
     cbv_flow_invitation = CbvFlowInvitation.new(cbv_flow_invitation_params)
 
@@ -11,22 +11,29 @@ class CbvInvitationService
 
     deliver(cbv_flow_invitation, delivery_method)
 
-    track_event(cbv_flow_invitation, current_user)
+    track_event(cbv_flow_invitation, current_user, metrics_attributes)
 
     cbv_flow_invitation
   end
 
   private
 
-  def track_event(cbv_flow_invitation, current_user)
-    @event_logger.track(TrackEvent::CaseworkerInvitedApplicantToFlow, nil, {
+  def track_event(cbv_flow_invitation, current_user, metrics_attributes = {})
+    system_properties = {
       time: Time.now.to_i,
       user_id: current_user.id,
       caseworker_email_address: current_user.email,
       client_agency_id: current_user.client_agency_id,
       cbv_applicant_id: cbv_flow_invitation.cbv_applicant_id,
       invitation_id: cbv_flow_invitation.id
-    })
+    }
+
+    # guard against possible future key collision, system_property will override
+    @event_logger.track(
+      TrackEvent::CaseworkerInvitedApplicantToFlow,
+      nil,
+      (metrics_attributes || {}).merge(system_properties)
+    )
   end
 
   def deliver(cbv_flow_invitation, delivery_method)

--- a/app/app/services/transmitters/json_transmitter.rb
+++ b/app/app/services/transmitters/json_transmitter.rb
@@ -5,14 +5,14 @@ class Transmitters::JsonTransmitter
     api_url = URI(@current_agency.transmission_method_configuration["url"])
     include_report_pdf = @current_agency.transmission_method_configuration["include_report_pdf"]
     req = Net::HTTP::Post.new(api_url)
-    agency_partner_metadata = CbvApplicant.build_agency_partner_metadata(@current_agency.id) { |attr| @cbv_flow.cbv_applicant.public_send(attr) }
+    custom_attributes = CbvApplicant.build_custom_attributes(@current_agency.id) { |attr| @cbv_flow.cbv_applicant.public_send(attr) }
 
     req.content_type = "application/json"
 
     payload = {
       confirmation_code: @cbv_flow.confirmation_code,
       completed_at: @cbv_flow.consented_to_authorized_use_at.iso8601,
-      agency_partner_metadata: agency_partner_metadata,
+      custom_attributes: custom_attributes,
       income_report: @aggregator_report.income_report
     }
 

--- a/app/db/migrate/20260512164251_rename_agency_partner_metadata_to_custom_attributes.rb
+++ b/app/db/migrate/20260512164251_rename_agency_partner_metadata_to_custom_attributes.rb
@@ -1,0 +1,5 @@
+class RenameAgencyPartnerMetadataToCustomAttributes < ActiveRecord::Migration[7.2]
+  def change
+    rename_column :cbv_applicants, :agency_partner_metadata, :custom_attributes
+  end
+end

--- a/app/db/schema.rb
+++ b/app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_05_200002) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_12_164251) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -35,7 +35,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_05_200002) do
     t.jsonb "income_changes"
     t.date "date_of_birth"
     t.string "doc_id"
-    t.jsonb "agency_partner_metadata", default: {}, null: false
+    t.jsonb "custom_attributes", default: {}, null: false
     t.string "partner_identifier"
     t.index ["partner_identifier"], name: "index_cbv_applicants_on_partner_identifier"
   end

--- a/app/lib/mixpanel_event_tracker.rb
+++ b/app/lib/mixpanel_event_tracker.rb
@@ -17,16 +17,15 @@ class MixpanelEventTracker
       tracker_attrs.merge!({ "$ip": request_attributes.remote_ip })
     end
 
-    # For caseworker events, use the "user_id" attribute as the distinct_id
-    # For client events, use the "cbv_applicant_id" attribute as the distinct_id as it currently best
-    # represents the concept of a unique user.
+    # Tie the invitation creation MP event to the applicant it is being created for to help reporting.
+    # TODO: this will need an update if the caseworker portal is re-activated at any point
     user_id = attributes.fetch(:user_id, "")
     applicant_id = attributes.fetch(:cbv_applicant_id, "")
     prefix = ENV["MIXPANEL_DISTINCT_ID_PREFIX"].present? ? "#{ENV["MIXPANEL_DISTINCT_ID_PREFIX"]}-" : ""
-    if user_id.present?
-      distinct_id = "#{prefix}caseworker-#{user_id}"
-    elsif applicant_id.present?
+    if applicant_id.present?
       distinct_id = "#{prefix}applicant-#{applicant_id}"
+    elsif user_id.present?
+      distinct_id = "#{prefix}caseworker-#{user_id}"
     end
 
     # This creates a profile for a distinct user

--- a/app/spec/controllers/api/invitations_controller_spec.rb
+++ b/app/spec/controllers/api/invitations_controller_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe Api::InvitationsController do
 
     let(:valid_params) do
       attributes_for(:cbv_flow_invitation, client_agency_id).tap do |params|
-        params[:agency_partner_metadata] = attributes_for(:cbv_applicant, client_agency_id)
+        params[:custom_attributes] = attributes_for(:cbv_applicant, client_agency_id)
         # ensure that client_agency_id is not considered a valid param. it should be inferred from the api token
-        params[:agency_partner_metadata].delete(:client_agency_id)
+        params[:custom_attributes].delete(:client_agency_id)
         params.delete(:client_agency_id)
       end
     end
@@ -43,10 +43,10 @@ RSpec.describe Api::InvitationsController do
 
 
     # TODO: See invitations_controller note on if we are including the echo-back metadata
-    # it "includes all agency_partner_metadata fields in the response" do
+    # it "includes all custom_attributes fields in the response" do
     #   subject
     #   parsed_response = JSON.parse(response.body)
-    #   expect(parsed_response["agency_partner_metadata"].keys.map(&:to_sym)).to match_array(
+    #   expect(parsed_response["custom_attributes"].keys.map(&:to_sym)).to match_array(
     #     CbvApplicant.valid_attributes_for_agency(client_agency_id.to_s)
     #   )
     # end
@@ -82,7 +82,7 @@ RSpec.describe Api::InvitationsController do
       let(:client_agency_id) { "la_ldh".to_sym }
       let(:valid_params) do
         attributes_for(:cbv_flow_invitation, client_agency_id).tap do |params|
-          params[:agency_partner_metadata] = {
+          params[:custom_attributes] = {
             doc_id: "ABC1234"
           }
         end
@@ -102,13 +102,13 @@ RSpec.describe Api::InvitationsController do
       end
 
       # TODO: See invitations_controller note on if we are including the echo-back metadata
-      # it "returns the expected agency_partner_metadata" do
+      # it "returns the expected custom_attributes" do
       #   subject
       #   parsed_response = JSON.parse(response.body)
-      #   expect(parsed_response["agency_partner_metadata"]).to eq(
-      #     "doc_id" => valid_params[:agency_partner_metadata][:doc_id],
-      #     "case_number" => valid_params[:agency_partner_metadata][:case_number],
-      #     "date_of_birth" => valid_params[:agency_partner_metadata][:date_of_birth],
+      #   expect(parsed_response["custom_attributes"]).to eq(
+      #     "doc_id" => valid_params[:custom_attributes][:doc_id],
+      #     "case_number" => valid_params[:custom_attributes][:case_number],
+      #     "date_of_birth" => valid_params[:custom_attributes][:date_of_birth],
       #   )
       # end
     end
@@ -132,7 +132,7 @@ RSpec.describe Api::InvitationsController do
 
     context "invalid params" do
       let(:invalid_params) do
-        valid_params[:agency_partner_metadata].delete(:first_name)
+        valid_params[:custom_attributes].delete(:first_name)
         valid_params
       end
 
@@ -150,14 +150,58 @@ RSpec.describe Api::InvitationsController do
         error_fields = parsed_response["errors"].map { |e| e["field"] }
 
         expect(error_fields).not_to include("cbv_applicant")
-        expect(error_fields).to include("agency_partner_metadata.first_name")
+        expect(error_fields).to include("custom_attributes.first_name")
+      end
+    end
+
+    context "legacy agency_partner_metadata param" do
+      let(:legacy_params) do
+        valid_params.tap do |p|
+          p[:agency_partner_metadata] = p.delete(:custom_attributes)
+        end
+      end
+
+      it "is accepted and routed through the same invitation flow" do
+        expect {
+          post :create, params: legacy_params
+        }.to change(CbvFlowInvitation, :count).by(1)
+          .and change(CbvApplicant, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+      end
+
+      it "emits the canonical custom_attributes prefix in error responses" do
+        legacy_params[:agency_partner_metadata].delete(:first_name)
+        post :create, params: legacy_params
+
+        expect(response).to have_http_status(:bad_request)
+        error_fields = JSON.parse(response.body)["errors"].map { |e| e["field"] }
+        expect(error_fields).to include("custom_attributes.first_name")
+        expect(error_fields).not_to include("agency_partner_metadata.first_name")
+      end
+    end
+
+    context "when both custom_attributes and agency_partner_metadata are supplied" do
+      let(:conflicting_params) do
+        valid_params.merge(agency_partner_metadata: valid_params[:custom_attributes])
+      end
+
+      it "returns 400 without creating any records" do
+        expect {
+          post :create, params: conflicting_params
+        }.not_to change(CbvFlowInvitation, :count)
+
+        expect(response).to have_http_status(:bad_request)
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response["errors"].first["field"]).to eq("custom_attributes")
+        expect(parsed_response["errors"].first["message"]).to match(/Provide either custom_attributes or agency_partner_metadata/)
       end
     end
 
     context "params not included in the agency's valid attributes" do
       let(:params_with_invalid_attributes) do
         # doc_id is not valid for sandbox
-        valid_params[:agency_partner_metadata][:doc_id] = "1234567"
+        valid_params[:custom_attributes][:doc_id] = "1234567"
         valid_params
       end
 

--- a/app/spec/controllers/api/invitations_controller_spec.rb
+++ b/app/spec/controllers/api/invitations_controller_spec.rb
@@ -215,6 +215,105 @@ RSpec.describe Api::InvitationsController do
       end
     end
 
+    context "with a malformed JSON body" do
+      it "returns a structured 400 explaining the parse failure" do
+        request.headers["Content-Type"] = "application/json"
+        request.headers["Authorization"] = "Bearer #{api_access_token_instance.access_token}"
+
+        # Missing comma between objects — invalid JSON
+        post :create, body: '{"custom_attributes": {"application_id": "1234"} "language": "en"}'
+
+        expect(response).to have_http_status(:bad_request)
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response["errors"]).to be_an(Array)
+        first = parsed_response["errors"].first
+        expect(first["field"]).to eq("body")
+        expect(first["message"]).to match(/Request body is not valid JSON/)
+      end
+
+      it "returns a structured 400 for a truncated body" do
+        request.headers["Content-Type"] = "application/json"
+        request.headers["Authorization"] = "Bearer #{api_access_token_instance.access_token}"
+
+        post :create, body: '{'
+
+        expect(response).to have_http_status(:bad_request)
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response["errors"].first["field"]).to eq("body")
+        expect(parsed_response["errors"].first["message"]).to match(/Request body is not valid JSON/)
+      end
+    end
+
+    context "with metrics_attributes" do
+      let(:fake_event_logger) { instance_double(GenericEventTracker, track: nil) }
+
+      before do
+        allow(GenericEventTracker).to receive(:new).and_return(fake_event_logger)
+      end
+
+      it "forwards keys with an ensured x- prefix (lowercased) to the CaseworkerInvitedApplicantToFlow event" do
+        params_with_metrics = valid_params.merge(metrics_attributes: {
+          "X-Request-ID" => "abc-123",
+          "Source" => "ops_console",
+          "campaign_id" => "42"
+        })
+
+        post :create, params: params_with_metrics
+
+        expect(response).to have_http_status(:created)
+        expect(fake_event_logger).to have_received(:track).with(
+          'CaseworkerInvitedApplicantToFlow',
+          nil,
+          hash_including(
+            "x-request-id" => "abc-123",
+            "x-source" => "ops_console",
+            "x-campaign_id" => "42"
+          )
+        )
+      end
+
+      it "does not double-prefix keys that already begin with x-" do
+        post :create, params: valid_params.merge(metrics_attributes: {
+          "x-trace" => "lower",
+          "X-Trace-Id" => "mixed-case"
+        })
+
+        expect(fake_event_logger).to have_received(:track).with(
+          'CaseworkerInvitedApplicantToFlow',
+          nil,
+          hash_including("x-trace" => "lower", "x-trace-id" => "mixed-case")
+        )
+      end
+
+      it "does not persist metrics_attributes anywhere on the invitation or applicant" do
+        post :create, params: valid_params.merge(metrics_attributes: { "trace" => "xyz" })
+
+        invitation = CbvFlowInvitation.last
+        expect(invitation.attributes).not_to include("trace")
+        expect(invitation.attributes).not_to include("x-trace")
+        expect(invitation.cbv_applicant.custom_attributes).not_to include("trace")
+        expect(invitation.cbv_applicant.custom_attributes).not_to include("x-trace")
+        expect(invitation.cbv_applicant.custom_attributes).not_to include("metrics_attributes")
+      end
+
+      it "creates the invitation normally when metrics_attributes is omitted" do
+        post :create, params: valid_params
+
+        expect(response).to have_http_status(:created)
+        expect(fake_event_logger).to have_received(:track).with(
+          'CaseworkerInvitedApplicantToFlow',
+          nil,
+          hash_including(:invitation_id)
+        )
+      end
+
+      it "tolerates an empty metrics_attributes hash" do
+        post :create, params: valid_params.merge(metrics_attributes: {})
+
+        expect(response).to have_http_status(:created)
+      end
+    end
+
     context "unauthorized user" do
       before do
         request.headers["Authorization"] = nil

--- a/app/spec/controllers/api/invitations_controller_spec.rb
+++ b/app/spec/controllers/api/invitations_controller_spec.rb
@@ -182,19 +182,19 @@ RSpec.describe Api::InvitationsController do
     end
 
     context "when both custom_attributes and agency_partner_metadata are supplied" do
-      let(:conflicting_params) do
-        valid_params.merge(agency_partner_metadata: valid_params[:custom_attributes])
+      let(:dual_params) do
+        valid_params.merge(
+          custom_attributes: valid_params[:custom_attributes].merge(case_number: "WINNER"),
+          agency_partner_metadata: valid_params[:custom_attributes].merge(case_number: "LOSER")
+        )
       end
 
-      it "returns 400 without creating any records" do
-        expect {
-          post :create, params: conflicting_params
-        }.not_to change(CbvFlowInvitation, :count)
+      it "uses custom_attributes and ignores agency_partner_metadata" do
+        post :create, params: dual_params
 
-        expect(response).to have_http_status(:bad_request)
-        parsed_response = JSON.parse(response.body)
-        expect(parsed_response["errors"].first["field"]).to eq("custom_attributes")
-        expect(parsed_response["errors"].first["message"]).to match(/Provide either custom_attributes or agency_partner_metadata/)
+        expect(response).to have_http_status(:created)
+        invitation = CbvFlowInvitation.last
+        expect(invitation.cbv_applicant.case_number).to eq("WINNER")
       end
     end
 

--- a/app/spec/lib/mixpanel_event_tracker_spec.rb
+++ b/app/spec/lib/mixpanel_event_tracker_spec.rb
@@ -68,6 +68,18 @@ RSpec.describe MixpanelEventTracker do
           tracker.track(event_type, request, { user_id: "456" })
         end
       end
+
+      context 'precedence when both cbv_applicant_id and user_id are present' do
+        before do
+          allow(ENV).to receive(:[]).and_call_original
+          allow(ENV).to receive(:[]).with("MIXPANEL_DISTINCT_ID_PREFIX").and_return(nil)
+        end
+
+        it 'prefers cbv_applicant_id so caseworker-initiated events group under the applicant' do
+          expect_any_instance_of(Mixpanel::Tracker).to receive(:track).with("applicant-123", event_type, anything)
+          tracker.track(event_type, request, { cbv_applicant_id: "123", user_id: "456" })
+        end
+      end
     end
   end
 end

--- a/app/spec/services/cbv_invitation_service_spec.rb
+++ b/app/spec/services/cbv_invitation_service_spec.rb
@@ -105,5 +105,48 @@ RSpec.describe CbvInvitationService, type: :service do
         )
       end
     end
+
+    context 'metrics_attributes' do
+      it 'merges supplied metrics_attributes into the tracked event' do
+        service.invite(
+          cbv_flow_invitation_params,
+          current_user,
+          delivery_method: nil,
+          metrics_attributes: { "source" => "ops_console", "campaign" => "spring2026" }
+        )
+
+        expect(event_logger).to have_received(:track).with(
+          'CaseworkerInvitedApplicantToFlow',
+          nil,
+          hash_including("source" => "ops_console", "campaign" => "spring2026")
+        )
+      end
+
+      it 'does not let metrics_attributes overwrite system-set properties' do
+        service.invite(
+          cbv_flow_invitation_params,
+          current_user,
+          delivery_method: nil,
+          metrics_attributes: { invitation_id: "spoofed", user_id: "spoofed" }
+        )
+
+        invitation = CbvFlowInvitation.last
+        expect(event_logger).to have_received(:track).with(
+          'CaseworkerInvitedApplicantToFlow',
+          nil,
+          hash_including(invitation_id: invitation.id, user_id: current_user.id)
+        )
+      end
+
+      it 'still tracks the event when metrics_attributes is empty or omitted' do
+        service.invite(cbv_flow_invitation_params, current_user, delivery_method: nil)
+
+        expect(event_logger).to have_received(:track).with(
+          'CaseworkerInvitedApplicantToFlow',
+          nil,
+          hash_including(:invitation_id)
+        )
+      end
+    end
   end
 end

--- a/app/spec/services/data_retention_service_spec.rb
+++ b/app/spec/services/data_retention_service_spec.rb
@@ -557,7 +557,7 @@ RSpec.describe DataRetentionService do
       expect(applicant.redacted_at).to be_within(1.second).of(Time.now)
 
       expect(applicant.first_name).to eq("REDACTED")
-      expect(applicant.agency_partner_metadata).to include("first_name" => "REDACTED")
+      expect(applicant.custom_attributes).to include("first_name" => "REDACTED")
 
       expect(applicant.partner_identifier).to eq("DELETEME001")
 

--- a/app/spec/support/title_checker_helper.rb
+++ b/app/spec/support/title_checker_helper.rb
@@ -23,8 +23,11 @@ RSpec.configure do |config|
   end
 
   def should_check_title?(request, response)
-    (request.get? || request.params[:action] == 'show') &&
-      !%w[new create].include?(request.params[:action]) &&
+    # Use path_parameters (route-based) rather than request.params so this
+    # check doesn't re-trigger body parsing on requests with a malformed JSON body.
+    action = request.path_parameters[:action]
+    (request.get? || action == 'show') &&
+      !%w[new create].include?(action) &&
       response.body.present? &&
       response.status == 200 &&
       response.content_type =~ /html/


### PR DESCRIPTION
## Summary
Modify invitation creation so that we accept custom_attributes instead of agency_partner_metadata, but still allow for the latter to not break legacy stuff. Accept metrics_attributes, and store them on mixpanel invitation creation event. Update invitation creation so that it has a matching applicant id.

## Type of Change
Check all that apply.
- [ ] Bug
- [X] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
* rename agency_partner_metadata to custom_attributes
* allow metrics_attributes in invitation
* store metrics attributes on mp event
* update invitation creation mp event to have distinct id that matches the applicant

## Checklist
- [X] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
[if anything need special attention, note it here]
