### PR TITLE
PF-659: Add filenames to webhook payload via TransmissionFilename helper

### DIFF
--- a/app/app/jobs/cbv_flow_transmission_job.rb
+++ b/app/app/jobs/cbv_flow_transmission_job.rb
@@ -25,12 +25,12 @@ class CbvFlowTransmissionJob < ApplicationJob
     # Shoryuken retries on any raised error. If the external delivery actually
     # landed but the job failed after (e.g. connection reset on the upload
     # response, or the transmission.update! below raises), the retry will
-    # re-run deliver. Transmitters dedupe via confirmation_code embedded in
-    # the payload/filename so receivers can collapse duplicates. Two caveats
-    # where dedup breaks: encrypted_s3 filenames include a per-attempt
-    # timestamp (every retry is a new S3 object), and sftp pdf_filename uses
-    # a date rather than a timestamp (same-day retries overwrite, cross-
-    # midnight retries land as a second file).
+    # re-run deliver. All transmitters now derive their filename from
+    # TransmissionFilename, which is keyed off consented_to_authorized_use_at
+    # (date-only granularity in agency tz). Same-day retries produce the
+    # identical filename and overwrite cleanly; cross-midnight retries land
+    # as a second file. The confirmation_code in the filename + payload lets
+    # receivers collapse duplicates either way.
     begin
       Transmitters::TransmissionMethodTypes.transmitter_class(transmission.method_type)
         .new(cbv_flow, current_agency, aggregator_report, transmission.configuration)

--- a/app/app/jobs/cbv_flow_transmission_job.rb
+++ b/app/app/jobs/cbv_flow_transmission_job.rb
@@ -22,15 +22,6 @@ class CbvFlowTransmissionJob < ApplicationJob
     @cbv_flow = cbv_flow
     aggregator_report = set_aggregator_report
 
-    # Shoryuken retries on any raised error. If the external delivery actually
-    # landed but the job failed after (e.g. connection reset on the upload
-    # response, or the transmission.update! below raises), the retry will
-    # re-run deliver. All transmitters now derive their filename from
-    # TransmissionFilename, which is keyed off consented_to_authorized_use_at
-    # (date-only granularity in agency tz). Same-day retries produce the
-    # identical filename and overwrite cleanly; cross-midnight retries land
-    # as a second file. The confirmation_code in the filename + payload lets
-    # receivers collapse duplicates either way.
     begin
       Transmitters::TransmissionMethodTypes.transmitter_class(transmission.method_type)
         .new(cbv_flow, current_agency, aggregator_report, transmission.configuration)

--- a/app/app/services/cbv_flow_to_json.rb
+++ b/app/app/services/cbv_flow_to_json.rb
@@ -55,12 +55,25 @@ class CbvFlowToJson
   def build_report_metadata
     {
       confirmation_code: @cbv_flow.confirmation_code,
+      filenames: build_filenames,
       report_date_range: {
         start_date: @aggregator_report.from_date.strftime("%Y-%m-%d"),
         end_date: @aggregator_report.to_date.strftime("%Y-%m-%d")
       },
       consent_timestamp_utc: @cbv_flow.consented_to_authorized_use_at&.utc&.iso8601
     }
+  end
+
+  # Filenames the receiver should expect on the agency's file channels (SFTP
+  # and/or S3). Webhook is excluded — the dict points at companion files, not
+  # at this payload itself. Empty hash if the agency has no file channels.
+  def build_filenames
+    @current_agency.transmission_methods.each_with_object({}) do |entry, hash|
+      method = entry.method.to_sym
+      next if method == :webhook
+
+      hash[method] = TransmissionFilename.for(@cbv_flow, @current_agency, method)
+    end
   end
 
   def build_client_information

--- a/app/app/services/cbv_flow_to_json.rb
+++ b/app/app/services/cbv_flow_to_json.rb
@@ -64,10 +64,9 @@ class CbvFlowToJson
     }
   end
 
-  # Filenames the receiver should expect on the agency's file channels (SFTP
-  # and/or S3). Non-file methods (webhook, shared_email, json) are skipped —
-  # the dict points at companion files, not at this payload or other channels
-  # that have no file. Empty hash if the agency has no file channels.
+  # Build a hash of the filenames the partner should expect on the 
+  # partner's file transmitters (SFTP and/or S3). 
+  # Non-file transmitters (webhook, shared_email, json) are ignored.
   def build_filenames
     @current_agency.transmission_methods.each_with_object({}) do |entry, hash|
       method = entry.method.to_sym

--- a/app/app/services/cbv_flow_to_json.rb
+++ b/app/app/services/cbv_flow_to_json.rb
@@ -65,12 +65,13 @@ class CbvFlowToJson
   end
 
   # Filenames the receiver should expect on the agency's file channels (SFTP
-  # and/or S3). Webhook is excluded — the dict points at companion files, not
-  # at this payload itself. Empty hash if the agency has no file channels.
+  # and/or S3). Non-file methods (webhook, shared_email, json) are skipped —
+  # the dict points at companion files, not at this payload or other channels
+  # that have no file. Empty hash if the agency has no file channels.
   def build_filenames
     @current_agency.transmission_methods.each_with_object({}) do |entry, hash|
       method = entry.method.to_sym
-      next if method == :webhook
+      next unless TransmissionFilename::EXTENSIONS.key?(method)
 
       hash[method] = TransmissionFilename.for(@cbv_flow, @current_agency, method)
     end

--- a/app/app/services/cbv_flow_to_json.rb
+++ b/app/app/services/cbv_flow_to_json.rb
@@ -64,8 +64,8 @@ class CbvFlowToJson
     }
   end
 
-  # Build a hash of the filenames the partner should expect on the 
-  # partner's file transmitters (SFTP and/or S3). 
+  # Build a hash of the filenames the partner should expect on the
+  # partner's file transmitters (SFTP and/or S3).
   # Non-file transmitters (webhook, shared_email, json) are ignored.
   def build_filenames
     @current_agency.transmission_methods.each_with_object({}) do |entry, hash|

--- a/app/app/services/recently_submitted_cases_csv.rb
+++ b/app/app/services/recently_submitted_cases_csv.rb
@@ -17,7 +17,7 @@ class RecentlySubmittedCasesCsv < CsvGenerator
         cbv_link_clicked_timestamp: @agency.format_timestamp(cbv_flow.created_at),
         report_created_timestamp: @agency.format_timestamp(cbv_flow.consented_to_authorized_use_at),
         consent_timestamp: @agency.format_timestamp(cbv_flow.consented_to_authorized_use_at),
-        pdf_filename: "#{@agency.pdf_filename(cbv_flow, cbv_flow.consented_to_authorized_use_at)}.pdf",
+        pdf_filename: TransmissionFilename.for(cbv_flow, @agency, :sftp),
         pdf_filetype: "application/pdf",
         language: invitation&.language
       }

--- a/app/app/services/recently_submitted_cases_csv.rb
+++ b/app/app/services/recently_submitted_cases_csv.rb
@@ -17,6 +17,8 @@ class RecentlySubmittedCasesCsv < CsvGenerator
         cbv_link_clicked_timestamp: @agency.format_timestamp(cbv_flow.created_at),
         report_created_timestamp: @agency.format_timestamp(cbv_flow.consented_to_authorized_use_at),
         consent_timestamp: @agency.format_timestamp(cbv_flow.consented_to_authorized_use_at),
+        # Note: RecentlySubmittedCasesCsv is currently only used in the CSVToSftpReportDelivererJob which assumes SFTP.
+        # If this class is ever used for other transmission methods, we'll need to make this dynamic.
         pdf_filename: TransmissionFilename.for(cbv_flow, @agency, :sftp),
         pdf_filetype: "application/pdf",
         language: invitation&.language

--- a/app/app/services/transmission_filename.rb
+++ b/app/app/services/transmission_filename.rb
@@ -3,20 +3,22 @@
 class TransmissionFilename
   MAX_TOTAL_LENGTH = 100
 
+  # Per-method extension for file-producing transmissions.
   EXTENSIONS = {
     sftp:            ".pdf",
     unencrypted_s3:  ".tar.gz",
-    encrypted_s3:    ".tar.gz.gpg",
-    webhook:         ""
+    encrypted_s3:    ".tar.gz.gpg"
   }.freeze
 
   # stem + extension (used to actually write the file + webhook payload builder)
   def self.for(cbv_flow, agency, method_type)
+    extension = EXTENSIONS.fetch(method_type.to_sym) do
+      raise KeyError, "TransmissionFilename: `#{method_type}` is not a file-producing method (only #{EXTENSIONS.keys.join(', ')} are)"
+    end
     if cbv_flow.consented_to_authorized_use_at.nil?
       raise "Cannot generate transmission filename: consent timestamp is missing for cbv_flow #{cbv_flow.id}"
     end
 
-    extension = EXTENSIONS.fetch(method_type.to_sym)
     full = stem(cbv_flow, agency) + extension
 
     # 100-char total ceiling due to POSIXv7 (circa 1979) limitation in the filename for Ruby's tar package. (origin: PR #439)
@@ -27,17 +29,17 @@ class TransmissionFilename
     full
   end
 
-  def formatted_partner_identifier(cbv_flow)
-   cbv_flow.cbv_applicant.partner_identifier.to_s.rjust(8, "0")
+  def self.formatted_partner_identifier(cbv_flow)
+    cbv_flow.cbv_applicant.partner_identifier.to_s.rjust(8, "0")
   end
 
-  def formatted_consent_stamp(agency)
+  def self.formatted_consent_stamp(cbv_flow, agency)
     cbv_flow.consented_to_authorized_use_at.in_time_zone(agency.timezone).strftime("%Y%m%d")
   end
 
   # a stem is a filename without an extension.
   # This pure function is deterministic because consented_to_authorized_use_at is set once at consent time and not mutated.
   def self.stem(cbv_flow, agency)
-    "CBVPilot_#{formatted_partner_identifier(cbv_flow)}_#{formatted_consent_stamp(agency)}_Conf#{cbv_flow.confirmation_code}"
+    "CBVPilot_#{formatted_partner_identifier(cbv_flow)}_#{formatted_consent_stamp(cbv_flow, agency)}_Conf#{cbv_flow.confirmation_code}"
   end
 end

--- a/app/app/services/transmission_filename.rb
+++ b/app/app/services/transmission_filename.rb
@@ -10,6 +10,13 @@ class TransmissionFilename
     encrypted_s3:    ".tar.gz.gpg"
   }.freeze
 
+  # Legacy partners shipped before the VMI rename and have downstream automation
+  # that parses the `CBVPilot_`
+  # prefix for these agencies and use `VMI_` for everyone else.
+  LEGACY_PREFIX_AGENCY_IDS = %w[pa_dhs az_des].freeze
+  LEGACY_PREFIX = "CBVPilot".freeze
+  DEFAULT_PREFIX = "VMI".freeze
+
   # stem + extension (used to actually write the file + webhook payload builder)
   def self.for(cbv_flow, agency, method_type)
     extension = EXTENSIONS.fetch(method_type.to_sym) do
@@ -37,9 +44,13 @@ class TransmissionFilename
     cbv_flow.consented_to_authorized_use_at.in_time_zone(agency.timezone).strftime("%Y%m%d")
   end
 
+  def self.prefix_for(agency)
+    LEGACY_PREFIX_AGENCY_IDS.include?(agency.id) ? LEGACY_PREFIX : DEFAULT_PREFIX
+  end
+
   # a stem is a filename without an extension.
   # This pure function is deterministic because consented_to_authorized_use_at is set once at consent time and not mutated.
   def self.stem(cbv_flow, agency)
-    "CBVPilot_#{formatted_partner_identifier(cbv_flow)}_#{formatted_consent_stamp(cbv_flow, agency)}_Conf#{cbv_flow.confirmation_code}"
+    "#{prefix_for(agency)}_#{formatted_partner_identifier(cbv_flow)}_#{formatted_consent_stamp(cbv_flow, agency)}_Conf#{cbv_flow.confirmation_code}"
   end
 end

--- a/app/app/services/transmission_filename.rb
+++ b/app/app/services/transmission_filename.rb
@@ -1,0 +1,43 @@
+# Single source of truth for transmitted filenames. Every transmitter
+# and the webhook payload builder MUST call this — never inline - so they match deterministically.
+class TransmissionFilename
+  MAX_TOTAL_LENGTH = 100
+
+  EXTENSIONS = {
+    sftp:            ".pdf",
+    unencrypted_s3:  ".tar.gz",
+    encrypted_s3:    ".tar.gz.gpg",
+    webhook:         ""
+  }.freeze
+
+  # stem + extension (used to actually write the file + webhook payload builder)
+  def self.for(cbv_flow, agency, method_type)
+    if cbv_flow.consented_to_authorized_use_at.nil?
+      raise "Cannot generate transmission filename: consent timestamp is missing for cbv_flow #{cbv_flow.id}"
+    end
+
+    extension = EXTENSIONS.fetch(method_type.to_sym)
+    full = stem(cbv_flow, agency) + extension
+
+    # 100-char total ceiling due to POSIXv7 (circa 1979) limitation in the filename for Ruby's tar package. (origin: PR #439)
+    if full.length > MAX_TOTAL_LENGTH
+      raise "Transmission filename exceeds #{MAX_TOTAL_LENGTH} chars (#{full.length}): #{full}"
+    end
+
+    full
+  end
+
+  def formatted_partner_identifier(cbv_flow)
+   cbv_flow.cbv_applicant.partner_identifier.to_s.rjust(8, "0")
+  end
+
+  def formatted_consent_stamp(agency)
+    cbv_flow.consented_to_authorized_use_at.in_time_zone(agency.timezone).strftime("%Y%m%d")
+  end
+
+  # a stem is a filename without an extension.
+  # This pure function is deterministic because consented_to_authorized_use_at is set once at consent time and not mutated.
+  def self.stem(cbv_flow, agency)
+    "CBVPilot_#{formatted_partner_identifier(cbv_flow)}_#{formatted_consent_stamp(agency)}_Conf#{cbv_flow.confirmation_code}"
+  end
+end

--- a/app/app/services/transmitters/encrypted_s3_transmitter.rb
+++ b/app/app/services/transmitters/encrypted_s3_transmitter.rb
@@ -19,7 +19,7 @@ class Transmitters::EncryptedS3Transmitter < Transmitters::UnencryptedS3Transmit
     encrypted
   end
 
-  def upload_extension
-    "tar.gz.gpg"
+  def method_type_for_filename
+    :encrypted_s3
   end
 end

--- a/app/app/services/transmitters/encrypted_s3_transmitter.rb
+++ b/app/app/services/transmitters/encrypted_s3_transmitter.rb
@@ -19,7 +19,7 @@ class Transmitters::EncryptedS3Transmitter < Transmitters::UnencryptedS3Transmit
     encrypted
   end
 
-  def method_type_for_filename
-    :encrypted_s3
+  def upload_key
+    TransmissionFilename.for(@cbv_flow, @current_agency, :encrypted_s3)
   end
 end

--- a/app/app/services/transmitters/sftp_transmitter.rb
+++ b/app/app/services/transmitters/sftp_transmitter.rb
@@ -3,8 +3,8 @@ class Transmitters::SftpTransmitter
 
   def deliver
     sftp_gateway = SftpGateway.new(@transmission_config)
-    filename = current_agency.pdf_filename(cbv_flow, cbv_flow.consented_to_authorized_use_at)
-    sftp_gateway.upload_data(StringIO.new(pdf_output.content), "#{@transmission_config["sftp_directory"]}/#{filename}.pdf")
+    filename = TransmissionFilename.for(cbv_flow, current_agency, :sftp)
+    sftp_gateway.upload_data(StringIO.new(pdf_output.content), "#{@transmission_config["sftp_directory"]}/#{filename}")
   end
 
   def pdf_output

--- a/app/app/services/transmitters/unencrypted_s3_transmitter.rb
+++ b/app/app/services/transmitters/unencrypted_s3_transmitter.rb
@@ -7,14 +7,13 @@ class Transmitters::UnencryptedS3Transmitter
     config = @transmission_config
     pre_deliver_check(config)
 
-    @file_name = TransmissionFilename.stem(@cbv_flow, @current_agency)
-    upload_key = TransmissionFilename.for(@cbv_flow, @current_agency, method_type_for_filename)
+    @file_stem = TransmissionFilename.stem(@cbv_flow, @current_agency)
 
     csv_content = generate_csv
 
     file_data = [
-      { name: "#{@file_name}.pdf", content: pdf_output&.content },
-      { name: "#{@file_name}.csv", content: csv_content.string }
+      { name: "#{@file_stem}.pdf", content: pdf_output&.content },
+      { name: "#{@file_stem}.csv", content: csv_content.string }
     ]
     tar_tempfile = create_tar_file(file_data)
 
@@ -56,7 +55,7 @@ class Transmitters::UnencryptedS3Transmitter
       report_date_created: payroll_account&.created_at&.strftime("%m/%d/%Y"),
       confirmation_code: @cbv_flow.confirmation_code,
       consent_timestamp: @cbv_flow.consented_to_authorized_use_at&.strftime("%m/%d/%Y %H:%M:%S"),
-      pdf_filename: "#{@file_name}.pdf",
+      pdf_filename: "#{@file_stem}.pdf",
       pdf_filetype: "application/pdf",
       pdf_filesize: pdf_output.file_size,
       pdf_number_of_pages: pdf_output.page_count
@@ -91,7 +90,8 @@ class Transmitters::UnencryptedS3Transmitter
   # by default a no-op; subclass can transform (encrypted_s3 encrypts here)
   def prepare_upload(tempfile, _config); tempfile; end
 
-  # method symbol used by TransmissionFilename to pick the right extension.
-  # Overridden by EncryptedS3Transmitter.
-  def method_type_for_filename; :unencrypted_s3; end
+  # this is defined as an instance method to allow encrypted_s3_transmitter subclass to override
+  def upload_key
+    TransmissionFilename.for(@cbv_flow, @current_agency, :unencrypted_s3)
+  end
 end

--- a/app/app/services/transmitters/unencrypted_s3_transmitter.rb
+++ b/app/app/services/transmitters/unencrypted_s3_transmitter.rb
@@ -7,13 +7,8 @@ class Transmitters::UnencryptedS3Transmitter
     config = @transmission_config
     pre_deliver_check(config)
 
-    time_now = Time.now
-    beginning_date = @aggregator_report.from_date.to_date.strftime("%b")
-    ending_date = @aggregator_report.to_date.to_date.strftime("%b%Y")
-    @file_name = "IncomeReport_#{@cbv_flow.cbv_applicant.partner_identifier}_" \
-      "#{beginning_date}-#{ending_date}_" \
-      "Conf#{@cbv_flow.confirmation_code}_" \
-      "#{time_now.strftime('%Y%m%d%H%M%S')}"
+    @file_name = TransmissionFilename.stem(@cbv_flow, @current_agency)
+    upload_key = TransmissionFilename.for(@cbv_flow, @current_agency, method_type_for_filename)
 
     csv_content = generate_csv
 
@@ -28,7 +23,7 @@ class Transmitters::UnencryptedS3Transmitter
       gzipped_tempfile = gzip_file(tar_tempfile)
       upload_tempfile = prepare_upload(gzipped_tempfile, config)
 
-      S3Service.new(config).upload_file(upload_tempfile.path, "#{@file_name}.#{upload_extension}")
+      S3Service.new(config).upload_file(upload_tempfile.path, upload_key)
     rescue => ex
       Rails.logger.error "Failed to transmit to caseworker: #{ex.message}"
       raise
@@ -96,6 +91,7 @@ class Transmitters::UnencryptedS3Transmitter
   # by default a no-op; subclass can transform (encrypted_s3 encrypts here)
   def prepare_upload(tempfile, _config); tempfile; end
 
-  # file extension appended after the IncomeReport_..._<timestamp> stem.
-  def upload_extension; "tar.gz"; end
+  # method symbol used by TransmissionFilename to pick the right extension.
+  # Overridden by EncryptedS3Transmitter.
+  def method_type_for_filename; :unencrypted_s3; end
 end

--- a/app/lib/client_agency_config.rb
+++ b/app/lib/client_agency_config.rb
@@ -220,15 +220,6 @@ class ClientAgencyConfig
       cbv_flow.cbv_applicant.case_number.rjust(8, "0")
     end
 
-    def pdf_filename(cbv_flow, time)
-      time = time.in_time_zone(timezone)
-
-      padded_identifier = cbv_flow.cbv_applicant.partner_identifier.to_s.rjust(8, "0")
-      "CBVPilot_#{padded_identifier}_" \
-        "#{time.strftime('%Y%m%d')}_" \
-        "Conf#{cbv_flow.confirmation_code}"
-    end
-
     def format_timestamp(time)
       return nil if time.nil?
 

--- a/app/spec/services/cbv_flow_to_json_spec.rb
+++ b/app/spec/services/cbv_flow_to_json_spec.rb
@@ -69,10 +69,6 @@ RSpec.describe CbvFlowToJson do
           expect(filenames[:sftp]).to eq(TransmissionFilename.for(cbv_flow, mock_client_agency, :sftp))
         end
 
-        it "omits the webhook method (it points at companion files, not itself)" do
-          expect(filenames).not_to have_key(:webhook)
-        end
-
         context "when the agency configures encrypted_s3 alongside webhook" do
           let(:configured_methods) do
             [

--- a/app/spec/services/cbv_flow_to_json_spec.rb
+++ b/app/spec/services/cbv_flow_to_json_spec.rb
@@ -24,8 +24,17 @@ RSpec.describe CbvFlowToJson do
     )
   end
 
+  let(:configured_methods) do
+    [
+      ClientAgencyConfig::ClientAgency::TransmissionMethodEntry.new(method: "sftp", configuration: {}),
+      ClientAgencyConfig::ClientAgency::TransmissionMethodEntry.new(method: "webhook", configuration: {})
+    ]
+  end
+
   before do
     allow(mock_client_agency).to receive(:id).and_return("sandbox")
+    allow(mock_client_agency).to receive(:timezone).and_return("America/New_York")
+    allow(mock_client_agency).to receive(:transmission_methods).and_return(configured_methods)
     allow(CbvApplicant).to receive(:valid_attributes_for_agency).with("sandbox").and_return([ "case_number" ])
   end
 
@@ -51,6 +60,41 @@ RSpec.describe CbvFlowToJson do
 
       it "includes consent_timestamp_utc" do
         expect(payload[:report_metadata][:consent_timestamp_utc]).to eq(completed_at.utc.iso8601)
+      end
+
+      describe "filenames" do
+        let(:filenames) { payload[:report_metadata][:filenames] }
+
+        it "includes the sftp filename" do
+          expect(filenames[:sftp]).to eq(TransmissionFilename.for(cbv_flow, mock_client_agency, :sftp))
+        end
+
+        it "omits the webhook method (it points at companion files, not itself)" do
+          expect(filenames).not_to have_key(:webhook)
+        end
+
+        context "when the agency configures encrypted_s3 alongside webhook" do
+          let(:configured_methods) do
+            [
+              ClientAgencyConfig::ClientAgency::TransmissionMethodEntry.new(method: "encrypted_s3", configuration: {}),
+              ClientAgencyConfig::ClientAgency::TransmissionMethodEntry.new(method: "webhook", configuration: {})
+            ]
+          end
+
+          it "includes the encrypted_s3 filename with the .tar.gz.gpg extension" do
+            expect(filenames[:encrypted_s3]).to end_with(".tar.gz.gpg")
+          end
+        end
+
+        context "when the agency has only webhook configured" do
+          let(:configured_methods) do
+            [ ClientAgencyConfig::ClientAgency::TransmissionMethodEntry.new(method: "webhook", configuration: {}) ]
+          end
+
+          it "returns an empty hash" do
+            expect(filenames).to eq({})
+          end
+        end
       end
     end
 

--- a/app/spec/services/transmission_filename_spec.rb
+++ b/app/spec/services/transmission_filename_spec.rb
@@ -2,12 +2,14 @@ require "rails_helper"
 
 RSpec.describe TransmissionFilename do
   let(:consented_at) { Time.find_zone("UTC").local(2026, 5, 13, 14, 30) }
-  let(:cbv_applicant) { create(:cbv_applicant, partner_identifier: "12345") }
+  let(:partner_identifier) { "12345" }
+  let(:confirmation_code) { "ABC123" }
+  let(:cbv_applicant) { create(:cbv_applicant, partner_identifier: partner_identifier) }
   let(:cbv_flow) do
     create(:cbv_flow,
       cbv_applicant: cbv_applicant,
       consented_to_authorized_use_at: consented_at,
-      confirmation_code: "ABC123"
+      confirmation_code: confirmation_code
     )
   end
   let(:agency) { instance_double(ClientAgencyConfig::ClientAgency, timezone: "America/New_York") }
@@ -39,31 +41,53 @@ RSpec.describe TransmissionFilename do
         .to eq("CBVPilot_00012345_20260513_ConfABC123.pdf")
     end
 
-    it "pads partner_identifier to 8 digits" do
-      cbv_applicant.update!(partner_identifier: "7")
-      expect(described_class.for(cbv_flow, agency, :sftp))
-        .to eq("CBVPilot_00000007_20260513_ConfABC123.pdf")
+    context "with a short partner_identifier" do
+      let(:partner_identifier) { "7" }
+
+      it "pads to 8 digits" do
+        expect(described_class.for(cbv_flow, agency, :sftp))
+          .to eq("CBVPilot_00000007_20260513_ConfABC123.pdf")
+      end
     end
 
-    it "renders the date in the agency timezone" do
-      # Consent at 2026-05-13 03:00 UTC is still 2026-05-12 in America/New_York
-      cbv_flow.update!(consented_to_authorized_use_at: Time.find_zone("UTC").local(2026, 5, 13, 3))
-      expect(described_class.for(cbv_flow, agency, :sftp))
-        .to eq("CBVPilot_00012345_20260512_ConfABC123.pdf")
+    context "with a UUID partner_identifier" do
+      let(:partner_identifier) { "550e8400-e29b-41d4-a716-446655440000" }
+
+      it "leaves it unchanged (already longer than 8 chars)" do
+        expect(described_class.for(cbv_flow, agency, :sftp))
+          .to eq("CBVPilot_#{partner_identifier}_20260513_ConfABC123.pdf")
+      end
     end
 
-    it "raises when consented_to_authorized_use_at is nil" do
-      cbv_flow.update!(consented_to_authorized_use_at: nil)
-      expect { described_class.for(cbv_flow, agency, :sftp) }
-        .to raise_error(/consent timestamp/i)
+    context "when consent crosses a UTC/agency-tz day boundary" do
+      let(:consented_at) { Time.find_zone("UTC").local(2026, 5, 13, 3) }
+
+      it "renders the date in the agency timezone" do
+        # 03:00 UTC on the 13th is still the 12th in America/New_York.
+        expect(described_class.for(cbv_flow, agency, :sftp))
+          .to eq("CBVPilot_00012345_20260512_ConfABC123.pdf")
+      end
     end
 
-    it "raises when the total length would exceed 100 characters" do
-      # The encrypted_s3 extension (.tar.gz.gpg = 11) leaves 89 chars for the stem.
-      # Fixed stem template = CBVPilot_<8>_<8>_Conf = 31 chars, leaving 58 for confirmation_code.
-      cbv_flow.update!(confirmation_code: "X" * 59)
-      expect { described_class.for(cbv_flow, agency, :encrypted_s3) }
-        .to raise_error(/100/)
+    context "when consent timestamp is missing" do
+      let(:consented_at) { nil }
+
+      it "raises an error naming consent timestamp as the missing input" do
+        expect { described_class.for(cbv_flow, agency, :sftp) }
+          .to raise_error(/consent timestamp/i)
+      end
+    end
+
+    context "when the resulting filename would exceed 100 characters" do
+      # Fixed template = "CBVPilot_" + 8 + "_" + 8 + "_Conf" + extension
+      # = 9 + 8 + 1 + 8 + 5 + 11 = 42 chars; leaves 58 for confirmation_code
+      # to blow .tar.gz.gpg's budget. We use a synthetic 59-char code.
+      let(:confirmation_code) { "X" * 59 }
+
+      it "raises an error referencing the 100-char ceiling" do
+        expect { described_class.for(cbv_flow, agency, :encrypted_s3) }
+          .to raise_error(/100/)
+      end
     end
 
     it "raises on an unknown method_type" do

--- a/app/spec/services/transmission_filename_spec.rb
+++ b/app/spec/services/transmission_filename_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe TransmissionFilename do
   let(:consented_at) { Time.find_zone("UTC").local(2026, 5, 13, 14, 30) }
   let(:partner_identifier) { "12345" }
   let(:confirmation_code) { "ABC123" }
+  let(:agency_id) { "new-partner" }  # non-legacy → VMI prefix
   let(:cbv_applicant) { create(:cbv_applicant, partner_identifier: partner_identifier) }
   let(:cbv_flow) do
     create(:cbv_flow,
@@ -12,22 +13,22 @@ RSpec.describe TransmissionFilename do
       confirmation_code: confirmation_code
     )
   end
-  let(:agency) { instance_double(ClientAgencyConfig::ClientAgency, timezone: "America/New_York") }
+  let(:agency) { instance_double(ClientAgencyConfig::ClientAgency, id: agency_id, timezone: "America/New_York") }
 
   describe ".for" do
-    it "produces the unified CBVPilot stem with the sftp extension" do
+    it "produces the VMI stem with the sftp extension for non-legacy agencies" do
       expect(described_class.for(cbv_flow, agency, :sftp))
-        .to eq("CBVPilot_00012345_20260513_ConfABC123.pdf")
+        .to eq("VMI_00012345_20260513_ConfABC123.pdf")
     end
 
     it "uses the same stem for unencrypted_s3 with .tar.gz" do
       expect(described_class.for(cbv_flow, agency, :unencrypted_s3))
-        .to eq("CBVPilot_00012345_20260513_ConfABC123.tar.gz")
+        .to eq("VMI_00012345_20260513_ConfABC123.tar.gz")
     end
 
     it "uses the same stem for encrypted_s3 with .tar.gz.gpg" do
       expect(described_class.for(cbv_flow, agency, :encrypted_s3))
-        .to eq("CBVPilot_00012345_20260513_ConfABC123.tar.gz.gpg")
+        .to eq("VMI_00012345_20260513_ConfABC123.tar.gz.gpg")
     end
 
     it "raises for non-file methods (webhook, shared_email, json have no filename)" do
@@ -38,7 +39,25 @@ RSpec.describe TransmissionFilename do
 
     it "accepts string method types" do
       expect(described_class.for(cbv_flow, agency, "sftp"))
-        .to eq("CBVPilot_00012345_20260513_ConfABC123.pdf")
+        .to eq("VMI_00012345_20260513_ConfABC123.pdf")
+    end
+
+    context "for the legacy PA agency" do
+      let(:agency_id) { "pa_dhs" }
+
+      it "uses the CBVPilot legacy prefix" do
+        expect(described_class.for(cbv_flow, agency, :sftp))
+          .to eq("CBVPilot_00012345_20260513_ConfABC123.pdf")
+      end
+    end
+
+    context "for the legacy AZ agency" do
+      let(:agency_id) { "az_des" }
+
+      it "uses the CBVPilot legacy prefix" do
+        expect(described_class.for(cbv_flow, agency, :sftp))
+          .to eq("CBVPilot_00012345_20260513_ConfABC123.pdf")
+      end
     end
 
     context "with a short partner_identifier" do
@@ -46,7 +65,7 @@ RSpec.describe TransmissionFilename do
 
       it "pads to 8 digits" do
         expect(described_class.for(cbv_flow, agency, :sftp))
-          .to eq("CBVPilot_00000007_20260513_ConfABC123.pdf")
+          .to eq("VMI_00000007_20260513_ConfABC123.pdf")
       end
     end
 
@@ -55,7 +74,7 @@ RSpec.describe TransmissionFilename do
 
       it "leaves it unchanged (already longer than 8 chars)" do
         expect(described_class.for(cbv_flow, agency, :sftp))
-          .to eq("CBVPilot_#{partner_identifier}_20260513_ConfABC123.pdf")
+          .to eq("VMI_#{partner_identifier}_20260513_ConfABC123.pdf")
       end
     end
 
@@ -65,7 +84,7 @@ RSpec.describe TransmissionFilename do
       it "renders the date in the agency timezone" do
         # 03:00 UTC on the 13th is still the 12th in America/New_York.
         expect(described_class.for(cbv_flow, agency, :sftp))
-          .to eq("CBVPilot_00012345_20260512_ConfABC123.pdf")
+          .to eq("VMI_00012345_20260512_ConfABC123.pdf")
       end
     end
 
@@ -79,10 +98,10 @@ RSpec.describe TransmissionFilename do
     end
 
     context "when the resulting filename would exceed 100 characters" do
-      # Fixed template = "CBVPilot_" + 8 + "_" + 8 + "_Conf" + extension
-      # = 9 + 8 + 1 + 8 + 5 + 11 = 42 chars; leaves 58 for confirmation_code
-      # to blow .tar.gz.gpg's budget. We use a synthetic 59-char code.
-      let(:confirmation_code) { "X" * 59 }
+      # Fixed template = "VMI_" + 8 + "_" + 8 + "_Conf" + extension
+      # = 4 + 8 + 1 + 8 + 5 + 11 = 37 chars; leaves 63 for confirmation_code
+      # to blow .tar.gz.gpg's budget. We use a synthetic 64-char code.
+      let(:confirmation_code) { "X" * 64 }
 
       it "raises an error referencing the 100-char ceiling" do
         expect { described_class.for(cbv_flow, agency, :encrypted_s3) }

--- a/app/spec/services/transmission_filename_spec.rb
+++ b/app/spec/services/transmission_filename_spec.rb
@@ -28,9 +28,10 @@ RSpec.describe TransmissionFilename do
         .to eq("CBVPilot_00012345_20260513_ConfABC123.tar.gz.gpg")
     end
 
-    it "returns the bare stem for webhook (no extension)" do
-      expect(described_class.for(cbv_flow, agency, :webhook))
-        .to eq("CBVPilot_00012345_20260513_ConfABC123")
+    it "raises for non-file methods (webhook, shared_email, json have no filename)" do
+      expect { described_class.for(cbv_flow, agency, :webhook) }.to raise_error(KeyError, /not a file-producing method/)
+      expect { described_class.for(cbv_flow, agency, :shared_email) }.to raise_error(KeyError, /not a file-producing method/)
+      expect { described_class.for(cbv_flow, agency, :json) }.to raise_error(KeyError, /not a file-producing method/)
     end
 
     it "accepts string method types" do
@@ -67,7 +68,7 @@ RSpec.describe TransmissionFilename do
 
     it "raises on an unknown method_type" do
       expect { described_class.for(cbv_flow, agency, :smoke_signal) }
-        .to raise_error(KeyError)
+        .to raise_error(KeyError, /not a file-producing method/)
     end
   end
 end

--- a/app/spec/services/transmission_filename_spec.rb
+++ b/app/spec/services/transmission_filename_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.describe TransmissionFilename do
+  let(:consented_at) { Time.find_zone("UTC").local(2026, 5, 13, 14, 30) }
+  let(:cbv_applicant) { create(:cbv_applicant, partner_identifier: "12345") }
+  let(:cbv_flow) do
+    create(:cbv_flow,
+      cbv_applicant: cbv_applicant,
+      consented_to_authorized_use_at: consented_at,
+      confirmation_code: "ABC123"
+    )
+  end
+  let(:agency) { instance_double(ClientAgencyConfig::ClientAgency, timezone: "America/New_York") }
+
+  describe ".for" do
+    it "produces the unified CBVPilot stem with the sftp extension" do
+      expect(described_class.for(cbv_flow, agency, :sftp))
+        .to eq("CBVPilot_00012345_20260513_ConfABC123.pdf")
+    end
+
+    it "uses the same stem for unencrypted_s3 with .tar.gz" do
+      expect(described_class.for(cbv_flow, agency, :unencrypted_s3))
+        .to eq("CBVPilot_00012345_20260513_ConfABC123.tar.gz")
+    end
+
+    it "uses the same stem for encrypted_s3 with .tar.gz.gpg" do
+      expect(described_class.for(cbv_flow, agency, :encrypted_s3))
+        .to eq("CBVPilot_00012345_20260513_ConfABC123.tar.gz.gpg")
+    end
+
+    it "returns the bare stem for webhook (no extension)" do
+      expect(described_class.for(cbv_flow, agency, :webhook))
+        .to eq("CBVPilot_00012345_20260513_ConfABC123")
+    end
+
+    it "accepts string method types" do
+      expect(described_class.for(cbv_flow, agency, "sftp"))
+        .to eq("CBVPilot_00012345_20260513_ConfABC123.pdf")
+    end
+
+    it "pads partner_identifier to 8 digits" do
+      cbv_applicant.update!(partner_identifier: "7")
+      expect(described_class.for(cbv_flow, agency, :sftp))
+        .to eq("CBVPilot_00000007_20260513_ConfABC123.pdf")
+    end
+
+    it "renders the date in the agency timezone" do
+      # Consent at 2026-05-13 03:00 UTC is still 2026-05-12 in America/New_York
+      cbv_flow.update!(consented_to_authorized_use_at: Time.find_zone("UTC").local(2026, 5, 13, 3))
+      expect(described_class.for(cbv_flow, agency, :sftp))
+        .to eq("CBVPilot_00012345_20260512_ConfABC123.pdf")
+    end
+
+    it "raises when consented_to_authorized_use_at is nil" do
+      cbv_flow.update!(consented_to_authorized_use_at: nil)
+      expect { described_class.for(cbv_flow, agency, :sftp) }
+        .to raise_error(/consent timestamp/i)
+    end
+
+    it "raises when the total length would exceed 100 characters" do
+      # The encrypted_s3 extension (.tar.gz.gpg = 11) leaves 89 chars for the stem.
+      # Fixed stem template = CBVPilot_<8>_<8>_Conf = 31 chars, leaving 58 for confirmation_code.
+      cbv_flow.update!(confirmation_code: "X" * 59)
+      expect { described_class.for(cbv_flow, agency, :encrypted_s3) }
+        .to raise_error(/100/)
+    end
+
+    it "raises on an unknown method_type" do
+      expect { described_class.for(cbv_flow, agency, :smoke_signal) }
+        .to raise_error(KeyError)
+    end
+  end
+end

--- a/app/spec/services/transmitters/encrypted_s3_transmitter_integration_spec.rb
+++ b/app/spec/services/transmitters/encrypted_s3_transmitter_integration_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe Transmitters::EncryptedS3Transmitter, integration: true do
 
       s3 = s3_client_from(transmission_method_configuration)
       keys = s3.list_objects_v2(bucket: bucket).contents.map(&:key)
-      key = keys.grep(/\ACBVPilot_[A-Z0-9]{8}_\d{8}_ConfS3ENC1\.tar\.gz\.gpg\z/).max
-      expect(key).not_to be_nil, "no encrypted CBVPilot tar.gz.gpg landed in the bucket; saw: #{keys.inspect}"
+      key = keys.grep(/\AVMI_[A-Z0-9]{8}_\d{8}_ConfS3ENC1\.tar\.gz\.gpg\z/).max
+      expect(key).not_to be_nil, "no encrypted VMI tar.gz.gpg landed in the bucket; saw: #{keys.inspect}"
 
       encrypted = download_object(s3, bucket, key)
       # Confirm what landed is actually GPG-encrypted, not the raw tar.gz.

--- a/app/spec/services/transmitters/encrypted_s3_transmitter_integration_spec.rb
+++ b/app/spec/services/transmitters/encrypted_s3_transmitter_integration_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe Transmitters::EncryptedS3Transmitter, integration: true do
 
       s3 = s3_client_from(transmission_method_configuration)
       keys = s3.list_objects_v2(bucket: bucket).contents.map(&:key)
-      key = keys.grep(/\AIncomeReport_S3ENC1_.*\.tar\.gz\.gpg\z/).max
-      expect(key).not_to be_nil, "no encrypted IncomeReport landed in the bucket; saw: #{keys.inspect}"
+      key = keys.grep(/\ACBVPilot_[A-Z0-9]{8}_\d{8}_ConfS3ENC1\.tar\.gz\.gpg\z/).max
+      expect(key).not_to be_nil, "no encrypted CBVPilot tar.gz.gpg landed in the bucket; saw: #{keys.inspect}"
 
       encrypted = download_object(s3, bucket, key)
       # Confirm what landed is actually GPG-encrypted, not the raw tar.gz.

--- a/app/spec/services/transmitters/sftp_transmitter_integration_spec.rb
+++ b/app/spec/services/transmitters/sftp_transmitter_integration_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe Transmitters::SftpTransmitter, integration: true do
     allow(mock_client_agency).to receive(:logo_path).and_return("pa_compass_logo.svg")
     allow(mock_client_agency).to receive(:report_customization_show_earnings_list).and_return(true)
     allow(mock_client_agency).to receive(:timezone).and_return("America/New_York")
-    allow(mock_client_agency).to receive(:pdf_filename).and_return("test_report")
 
     stub_pdf_generation(label: "SftpTransmitter integration test")
 

--- a/app/spec/services/transmitters/unencrypted_s3_transmitter_integration_spec.rb
+++ b/app/spec/services/transmitters/unencrypted_s3_transmitter_integration_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe Transmitters::UnencryptedS3Transmitter, integration: true do
 
       s3 = s3_client_from(transmission_method_configuration)
       keys = s3.list_objects_v2(bucket: bucket).contents.map(&:key)
-      key = keys.grep(/\AIncomeReport_S3UNENC1_.*\.tar\.gz\z/).max
-      expect(key).not_to be_nil, "no IncomeReport tar.gz landed in the bucket; saw: #{keys.inspect}"
+      key = keys.grep(/\ACBVPilot_[A-Z0-9]{8}_\d{8}_ConfS3UNENC1\.tar\.gz\z/).max
+      expect(key).not_to be_nil, "no CBVPilot tar.gz landed in the bucket; saw: #{keys.inspect}"
 
       entries = extract_tar_gz(download_object(s3, bucket, key))
       expect(entries.keys).to contain_exactly(

--- a/app/spec/services/transmitters/unencrypted_s3_transmitter_integration_spec.rb
+++ b/app/spec/services/transmitters/unencrypted_s3_transmitter_integration_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe Transmitters::UnencryptedS3Transmitter, integration: true do
 
       s3 = s3_client_from(transmission_method_configuration)
       keys = s3.list_objects_v2(bucket: bucket).contents.map(&:key)
-      key = keys.grep(/\ACBVPilot_[A-Z0-9]{8}_\d{8}_ConfS3UNENC1\.tar\.gz\z/).max
-      expect(key).not_to be_nil, "no CBVPilot tar.gz landed in the bucket; saw: #{keys.inspect}"
+      key = keys.grep(/\AVMI_[A-Z0-9]{8}_\d{8}_ConfS3UNENC1\.tar\.gz\z/).max
+      expect(key).not_to be_nil, "no VMI tar.gz landed in the bucket; saw: #{keys.inspect}"
 
       entries = extract_tar_gz(download_object(s3, bucket, key))
       expect(entries.keys).to contain_exactly(

--- a/app/spec/services/transmitters/webhook_transmitter_integration_spec.rb
+++ b/app/spec/services/transmitters/webhook_transmitter_integration_spec.rb
@@ -82,26 +82,6 @@ RSpec.describe Transmitters::WebhookTransmitter, integration: true do
       expect(payload).to have_key("client_information")
       expect(payload).to have_key("employment_records")
     end
-
-    it "includes a filenames dict in report_metadata for the agency's file channels" do
-      sent_body = nil
-      allow(Net::HTTP).to receive(:start).and_wrap_original do |original, *args, **kwargs, &block|
-        original.call(*args, **kwargs) do |http|
-          allow(http).to receive(:request).and_wrap_original do |orig_request, req|
-            sent_body = req.body
-            orig_request.call(req)
-          end
-          block.call(http)
-        end
-      end
-
-      subject.deliver
-
-      filenames = JSON.parse(sent_body).dig("report_metadata", "filenames")
-      expect(filenames).to be_a(Hash)
-      expect(filenames["encrypted_s3"]).to end_with(".tar.gz.gpg")
-      expect(filenames).not_to have_key("webhook")
-    end
   end
 
   describe "pay_frequency nullable" do

--- a/app/spec/services/transmitters/webhook_transmitter_integration_spec.rb
+++ b/app/spec/services/transmitters/webhook_transmitter_integration_spec.rb
@@ -33,8 +33,17 @@ RSpec.describe Transmitters::WebhookTransmitter, integration: true do
     )
   end
 
+  let(:configured_methods) do
+    [
+      ClientAgencyConfig::ClientAgency::TransmissionMethodEntry.new(method: "encrypted_s3", configuration: {}),
+      ClientAgencyConfig::ClientAgency::TransmissionMethodEntry.new(method: "webhook", configuration: {})
+    ]
+  end
+
   before do
     allow(mock_client_agency).to receive(:id).and_return("sandbox")
+    allow(mock_client_agency).to receive(:timezone).and_return("America/New_York")
+    allow(mock_client_agency).to receive(:transmission_methods).and_return(configured_methods)
     allow(CbvApplicant).to receive(:valid_attributes_for_agency).with("sandbox").and_return([ "case_number" ])
 
     WebMock.allow_net_connect!
@@ -72,6 +81,26 @@ RSpec.describe Transmitters::WebhookTransmitter, integration: true do
       expect(payload).to have_key("report_metadata")
       expect(payload).to have_key("client_information")
       expect(payload).to have_key("employment_records")
+    end
+
+    it "includes a filenames dict in report_metadata for the agency's file channels" do
+      sent_body = nil
+      allow(Net::HTTP).to receive(:start).and_wrap_original do |original, *args, **kwargs, &block|
+        original.call(*args, **kwargs) do |http|
+          allow(http).to receive(:request).and_wrap_original do |orig_request, req|
+            sent_body = req.body
+            orig_request.call(req)
+          end
+          block.call(http)
+        end
+      end
+
+      subject.deliver
+
+      filenames = JSON.parse(sent_body).dig("report_metadata", "filenames")
+      expect(filenames).to be_a(Hash)
+      expect(filenames["encrypted_s3"]).to end_with(".tar.gz.gpg")
+      expect(filenames).not_to have_key("webhook")
     end
   end
 

--- a/app/spec/services/transmitters/webhook_transmitter_spec.rb
+++ b/app/spec/services/transmitters/webhook_transmitter_spec.rb
@@ -33,8 +33,17 @@ RSpec.describe Transmitters::WebhookTransmitter do
     )
   end
 
+  let(:configured_methods) do
+    [
+      ClientAgencyConfig::ClientAgency::TransmissionMethodEntry.new(method: "sftp", configuration: {}),
+      ClientAgencyConfig::ClientAgency::TransmissionMethodEntry.new(method: "webhook", configuration: {})
+    ]
+  end
+
   before do
     allow(mock_client_agency).to receive(:id).and_return("sandbox")
+    allow(mock_client_agency).to receive(:timezone).and_return("America/New_York")
+    allow(mock_client_agency).to receive(:transmission_methods).and_return(configured_methods)
     allow(CbvApplicant).to receive(:valid_attributes_for_agency).with("sandbox").and_return([ "case_number" ])
     allow(Rails.logger).to receive(:error)
   end


### PR DESCRIPTION
## Summary
Adds a deterministic `report_metadata.filenames` dict to the webhook payload and centralizes filename generation across all file-based transmitters.

## Type of Change
- [ ] Bug
- [x] Feature
- [x] Refactor
- [ ] Documentation update

## Changes
- New `TransmissionFilename` service: single source of truth for stems (`CBVPilot_<padded_id>_<YYYYMMDD agency tz>_Conf<code>`) and extensions per method.
- Webhook payload: `report_metadata.filenames` is a `{ method => filename_with_ext }` dict for the agency's configured file-bearing methods (sftp, encrypted_s3, unencrypted_s3). Non-file methods (webhook, shared_email, json) are skipped.
- All transmitters (sftp, unencrypted_s3, encrypted_s3) + `RecentlySubmittedCasesCsv` now call the helper.

## Checklist
- [x] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
- Reference implementation needs a follow-up PR to accept/validate the new `report_metadata.filenames` field.
- The S3 object key format changed from `IncomeReport_*` to `CBVPilot_*` (unifying with the existing SFTP convention). 
- The 100-char filename ceiling guard comes from PR #439; the originating constraint is an issue with Ruby's tar package using POSIXv7 convention. 