### PR TITLE
remove raise error on paystub anamoly

### DIFF
--- a/app/app/services/aggregators/aggregator_reports/argyle_report.rb
+++ b/app/app/services/aggregators/aggregator_reports/argyle_report.rb
@@ -136,7 +136,6 @@ module Aggregators::AggregatorReports
         max_paystubs: max_paystubs,
         lookback_days: @fetched_days
       })
-      raise error
     end
 
     def transform_identities(identities_json)


### PR DESCRIPTION
## Summary
Gig workers have a lot of paystubs. Raising an error and stopping their flow on 'too many paystubs' is preventing users from completing the flow.

## Type of Change
Check all that apply.
- [X] Bug
- [ ] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
* remove the 'raise' on the checker for paystub count

## Checklist
- [ ] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
[if anything need special attention, note it here]
