### PR TITLE
fix cookie expiration

### DIFF
--- a/app/app/services/aggregators/aggregator_reports/argyle_report.rb
+++ b/app/app/services/aggregators/aggregator_reports/argyle_report.rb
@@ -113,9 +113,8 @@ module Aggregators::AggregatorReports
 
     # Guardrail against retrieving an anomalously large number of paystubs.
     # The cap is the lookback window (in days) x MAX_PAYSTUBS_PER_LOOKBACK_DAY.
-    # If the retrieved count reaches the cap, we surface the error to New Relic
-    # and raise to hard fail — we'd rather abort report generation than let an
-    # erroneously large set of paystubs get processed and crash the app.
+    # If the retrieved count reaches the cap, we surface the error to New Relic.
+    # We are not blocked the flow, so the user can still continue and finish, but we will want to look into why this happened.
     def check_paystub_volume(paystubs_json, payroll_account)
       max_paystubs = @fetched_days.to_i * MAX_PAYSTUBS_PER_LOOKBACK_DAY
       return if max_paystubs.zero?

--- a/app/config/initializers/session_store.rb
+++ b/app/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 Rails.application.config.session_store :cookie_store,
   key: "_iv_cbv_payroll_session",
-  expires_after: Rails.application.config.cbv_session_expires_after
+  expire_after: Rails.application.config.cbv_session_expires_after

--- a/app/spec/services/aggregators/aggregator_reports/argyle_report_spec.rb
+++ b/app/spec/services/aggregators/aggregator_reports/argyle_report_spec.rb
@@ -30,6 +30,45 @@ RSpec.describe Aggregators::AggregatorReports::ArgyleReport, type: :service do
     Timecop.freeze(today, &ex)
   end
 
+  describe "#check_paystub_volume (anomalous-paystub-count guardrail)" do
+    let(:report) do
+      Aggregators::AggregatorReports::ArgyleReport.new(
+        payroll_accounts: [ payroll_account ],
+        argyle_service: argyle_service,
+        days_to_fetch_for_w2: days_ago_to_fetch,
+        days_to_fetch_for_gig: days_ago_to_fetch_for_gig
+      )
+    end
+
+    before do
+      # cap = @fetched_days * MAX_PAYSTUBS_PER_LOOKBACK_DAY(2) = 10
+      report.instance_variable_set(:@fetched_days, 5)
+      allow(Rails.logger).to receive(:error)
+      allow(NewRelic::Agent).to receive(:notice_error)
+    end
+
+    it "surfaces an over-cap count to New Relic WITHOUT raising (report generation continues)" do
+      over_cap = { "results" => Array.new(10) { {} } } # 10 >= cap(10) -> fires
+
+      expect {
+        report.send(:check_paystub_volume, over_cap, payroll_account)
+      }.not_to raise_error
+
+      expect(NewRelic::Agent).to have_received(:notice_error).with(
+        an_instance_of(Aggregators::AggregatorReports::ArgyleReport::PaystubLimitExceededError),
+        custom_params: hash_including(paystub_count: 10, max_paystubs: 10, lookback_days: 5)
+      )
+    end
+
+    it "does nothing when the count is under the cap" do
+      under_cap = { "results" => Array.new(3) { {} } } # 3 < cap(10)
+
+      report.send(:check_paystub_volume, under_cap, payroll_account)
+
+      expect(NewRelic::Agent).not_to have_received(:notice_error)
+    end
+  end
+
   describe '#fetch_report_data' do
     let(:argyle_report) do
       Aggregators::AggregatorReports::ArgyleReport.new(


### PR DESCRIPTION
## Summary
Cookies never expire due to rails magic. Should be expire_after, not expires_after or rails doesn't recognize it.

## Type of Change
Check all that apply.
- [X] Bug
- [ ] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
* change 'expires_after' to 'expire_after'

## Checklist
- [X] Tests added/updated (if needed)
- [X] Docs updated (if needed)

## Notes for Reviewers
[if anything need special attention, note it here]
