### PR TITLE
Support acronym-less partners and abstract the agency website link

### DIFF
--- a/app/app/controllers/cbv/preview_controller.rb
+++ b/app/app/controllers/cbv/preview_controller.rb
@@ -94,6 +94,24 @@ class Cbv::PreviewController < ApplicationController
     end
   end
 
+  def entry
+    render_as("entries")
+  end
+
+  def expired_invitation
+    render_as("expired_invitations")
+  end
+
+  def session_timeout
+    render template: "cbv/sessions/timeout"
+  end
+
+  def success
+    @cbv_flow.confirmation_code ||= "PREVIEW0000"
+    @invitation_link = root_url
+    render_as("successes")
+  end
+
   def submit_pdf_as_html
     # Render the PDF template as HTML for debugging (no wkhtmltopdf conversion)
     is_caseworker = is_not_production? && params[:is_caseworker]

--- a/app/app/helpers/application_helper.rb
+++ b/app/app/helpers/application_helper.rb
@@ -66,6 +66,29 @@ module ApplicationHelper
     end
   end
 
+  # Agency name, with its acronym in parentheses only for partners that have one.
+  def agency_name_with_acronym
+    full_name = agency_translation("shared.agency_full_name")
+    return full_name if current_agency&.has_acronym == false
+
+    "#{full_name} (#{agency_translation('shared.agency_acronym')})"
+  end
+
+  # Builds the agency website link, matching the markup used inline today. The label
+  # is configurable per partner via shared.agency_website_link_label.
+  def agency_website_link(label: agency_website_link_label)
+    url = current_agency&.agency_contact_website
+    return label if url.blank?
+
+    link_to(label, url, target: "_blank", rel: "noopener noreferrer")
+  end
+
+  # The text for an agency website link/reference (e.g. "the COMPASS website").
+  def agency_website_link_label
+    agency_translation("shared.agency_website_link_label",
+      agency_portal_name: agency_translation("shared.agency_portal_name"))
+  end
+
   private
 
   # db translations should be forgiving on the keys used.

--- a/app/app/helpers/application_helper.rb
+++ b/app/app/helpers/application_helper.rb
@@ -67,6 +67,7 @@ module ApplicationHelper
   end
 
   # Agency name, with its acronym in parentheses only for partners that have one.
+  # E.g. "West Carolina Department of Public Health (WC-DPH)"
   def agency_name_with_acronym
     full_name = agency_translation("shared.agency_full_name")
     return full_name if current_agency&.has_acronym == false
@@ -74,8 +75,7 @@ module ApplicationHelper
     "#{full_name} (#{agency_translation('shared.agency_acronym')})"
   end
 
-  # Builds the agency website link, matching the markup used inline today. The label
-  # is configurable per partner via shared.agency_website_link_label.
+  # A reusable anchor tag to the agency portal
   def agency_website_link(label: agency_website_link_label)
     url = current_agency&.agency_contact_website
     return label if url.blank?
@@ -84,6 +84,7 @@ module ApplicationHelper
   end
 
   # The text for an agency website link/reference (e.g. "the COMPASS website").
+  # Controlled via the partner translation key "agency_website_link_label"
   def agency_website_link_label
     agency_translation("shared.agency_website_link_label",
       agency_portal_name: agency_translation("shared.agency_portal_name"))

--- a/app/app/views/cbv/entries/show.html.erb
+++ b/app/app/views/cbv/entries/show.html.erb
@@ -80,7 +80,7 @@
     <% end %>
     <% accordion.with_accordion_item do %>
       <%= t(".what_if_i_cant_use_this_body_1", agency_portal_name: agency_translation("shared.agency_portal_name")) %>
-      <%= agency_translation(".what_if_i_cant_use_this_body_2_html", agency_url: current_agency.agency_contact_website, agency_portal_name: agency_translation("shared.agency_portal_name")) %>
+      <%= agency_translation(".what_if_i_cant_use_this_body_2_html", website_link: agency_website_link) %>
     <% end %>
   <% end %>
 </div>

--- a/app/app/views/cbv/expired_invitations/show.html.erb
+++ b/app/app/views/cbv/expired_invitations/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, t(".title") %>
 
 <h1><%= t(".title") %></h1>
-<p><%= t(".body_1_html", agency_url: current_agency.agency_contact_website, agency_portal_name: agency_translation("shared.agency_portal_name")) %></p>
+<p><%= t(".body_1_html", website_link: agency_website_link) %></p>
 
 <div class="margin-top-3">
   <%= agency_translation(".cta_button_html", agency_url: agency_url) %>

--- a/app/app/views/cbv/sessions/timeout.html.erb
+++ b/app/app/views/cbv/sessions/timeout.html.erb
@@ -10,7 +10,7 @@
       </svg>
     </div>
     <div class="grid-col-fill">
-      <%= t("session_timeout.page.info_box_html", agency_contact_website: current_agency.agency_contact_website, agency_portal_name: agency_translation("shared.agency_portal_name")) %>
+      <%= t("session_timeout.page.info_box_html", website_link: agency_website_link(label: agency_translation("shared.agency_portal_name"))) %>
     </div>
   </div>
 </div>

--- a/app/app/views/cbv/submits/show.html.erb
+++ b/app/app/views/cbv/submits/show.html.erb
@@ -14,7 +14,7 @@
 <div data-controller="cbv-attestation-check">
   <%= form_with model: @cbv_flow, url: cbv_flow_submit_path, html: { class: "usa-form maxw-mobile-lg" }, builder: UswdsFormBuilder, method: "patch" do |f| %>
     <span class="d-block"> <abbr title="required" class="usa-hint--required">*</abbr> Required </span>
-    <%= f.check_box :consent_to_authorized_use, { 'label': agency_translation(".consent_checkbox_label_html", agency_full_name: agency_translation("shared.agency_full_name"), agency_acronym: agency_translation("shared.agency_acronym")),
+    <%= f.check_box :consent_to_authorized_use, { 'label': agency_translation(".consent_checkbox_label_html", agency_name_with_acronym: agency_name_with_acronym, agency_full_name: agency_translation("shared.agency_full_name"), agency_acronym: agency_translation("shared.agency_acronym")),
                                                   required: true,
                                                   data: {
                                                     action: "change->cbv-attestation-check#setButton",

--- a/app/app/views/cbv/successes/show.html.erb
+++ b/app/app/views/cbv/successes/show.html.erb
@@ -30,7 +30,7 @@
         <div class="usa-icon-list__content">
           <h3 class="margin-bottom-1"><%= t(".whats_next_1_title") %></h3>
           <p><%= t(".whats_next_1_li_1", agency_acronym: agency_translation("shared.agency_acronym")) %></p>
-          <p><%= t(".whats_next_1_li_2_html", agency_portal_name: agency_translation("shared.agency_portal_name"), agency_website: current_agency.agency_contact_website) %></p>
+          <p><%= t(".whats_next_1_li_2_html", website_link: agency_website_link) %></p>
         </div>
       </li>
       <li class="usa-icon-list__item">

--- a/app/app/views/cbv/synchronization_failures/show.html.erb
+++ b/app/app/views/cbv/synchronization_failures/show.html.erb
@@ -8,7 +8,7 @@
 <ol>
   <li><%= t(".option_1") %></li>
   <li><%= t(".option_2") %></li>
-  <li><%= t(".option_3", agency_portal_name: agency_translation("shared.agency_portal_name")) %></li>
+  <li><%= t(".option_3", website_label: agency_website_link_label) %></li>
   <% if @cbv_flow.has_account_with_required_data? %>
     <li><%= t("cbv.missing_results.show.continue_to_review", agency_acronym: agency_translation("shared.agency_acronym")) %></li>
   <% end %>

--- a/app/app/views/cbv/validation_failures/_other_ways_no_employer.html.erb
+++ b/app/app/views/cbv/validation_failures/_other_ways_no_employer.html.erb
@@ -1,7 +1,7 @@
 <p><%= t(".other_ways_description", agency_name: agency_translation("shared.agency_full_name")) %></p>
 
 <ul>
-  <li><%= t(".other_ways_option_1_html", agency_portal_name: agency_translation("shared.agency_portal_name"), agency_website: agency_url) %></li>
+  <li><%= t(".other_ways_option_1_html", website_link: agency_website_link(label: agency_translation("shared.agency_portal_name"))) %></li>
   <li><%= t(".other_ways_option_2") %></li>
   <li><%= t(".other_ways_option_3", agency_acronym: agency_translation("shared.agency_acronym")) %></li>
 </ul>

--- a/app/app/views/cbv/validation_failures/_other_ways_with_employer.html.erb
+++ b/app/app/views/cbv/validation_failures/_other_ways_with_employer.html.erb
@@ -18,7 +18,7 @@
 <p><%= t(".more_options_text", agency_name: agency_translation("shared.agency_full_name")) %></p>
 
 <ul>
-  <li><%= t(".more_options_1_html", agency_portal_name: agency_translation("shared.agency_portal_name"), agency_website: agency_url) %></li>
+  <li><%= t(".more_options_1_html", website_link: agency_website_link(label: agency_translation("shared.agency_portal_name"))) %></li>
   <li><%= t(".more_options_2") %></li>
   <li><%= t(".more_options_3", agency_acronym: agency_translation("shared.agency_acronym")) %></li>
 </ul>

--- a/app/app/views/layouts/preview.html.erb
+++ b/app/app/views/layouts/preview.html.erb
@@ -86,6 +86,7 @@
         <div class="preview-bar__controls" data-preview-toggle-target="controls">
 
           <% preview_routes = [
+              [ "Entry", cbv_flow_preview_entry_path ],
               [ "Employer Search", cbv_flow_preview_employer_search_path ],
               [ "Synchronizations", cbv_flow_preview_synchronizations_path ],
               [ "Sync Failures", cbv_flow_preview_synchronization_failures_path ],
@@ -93,6 +94,9 @@
               [ "Missing Results", cbv_flow_preview_missing_results_path ],
               [ "Payment Details", cbv_flow_preview_payment_details_path ],
               [ "Summary", cbv_flow_preview_summary_path ],
+              [ "Expired Invitation", cbv_flow_preview_expired_invitation_path ],
+              [ "Success", cbv_flow_preview_success_path ],
+              [ "Session Timeout", cbv_flow_preview_session_timeout_path ],
               [ "Submit (HTML)", cbv_flow_preview_submit_path ],
               [ "Submit (PDF as HTML)", cbv_flow_preview_submit_pdf_as_html_path ]
             ]

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -784,7 +784,7 @@ en:
       pa_dhs: COMPASS
       sandbox: VMI
     # Link/reference text for the agency's website. Partners without a distinct
-    # portal (e.g. Mirza) override this to just their name.
+    # portal override this to just their name.
     agency_website_link_label:
       default: the %{agency_portal_name} website
     app_name:

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -319,7 +319,7 @@ en:
         time_estimate: Most people can find, connect and review one job in about 5 minutes.
         what_if_i_cant_use_this_body_1: If you need to verify your income and can’t use this tool, then you’ll need to share your income information for this job directly with %{agency_portal_name}.
         what_if_i_cant_use_this_body_2_html:
-          default: Visit the <a href="%{agency_url}" target="_blank" rel="noopener noreferrer">%{agency_portal_name} website</a> for more information on how to submit documents.
+          default: Visit %{website_link} for more information on how to submit documents.
           la_ldh: 'You can: <ul><li>Upload documents through the Self Service Portal online at <a href="https://mymedicaid.la.gov/" target="_blank" rel="noopener noreferrer">https://mymedicaid.la.gov/</a></li><li>Send documents through US Mail: Louisiana Medicaid/LaCHIP, P.O. Box 91283, Baton Rouge, LA 70821-9278</li><li>Email documents: <a href="mailto:MyMedicaid@la.gov">MyMedicaid@la.gov</a></li><li>Bring your documents to the Medicaid office of choice.</li></ul>'
         what_if_i_cant_use_this_title: What if I can't use this tool?
         what_youll_do: What you’ll do
@@ -332,7 +332,7 @@ en:
     error_no_access: We weren't able to load payroll data for this account. Please click the link you received from your SNAP agency to try again.
     expired_invitations:
       show:
-        body_1_html: If you still need to verify your income, please submit your income information by visiting the <a href="%{agency_url}" target="_blank" rel="noopener noreferrer">%{agency_portal_name} website</a>.
+        body_1_html: If you still need to verify your income, please submit your income information by visiting %{website_link}.
         cta_button_html:
           la_ldh: <a href="%{agency_url}" class="usa-button" target="_blank" rel="noopener noreferrer">Visit LDH's website</a>
           sandbox: <a href="https://www.mass.gov/guides/how-to-contact-dta" class="usa-button" target="_blank" rel="noopener noreferrer">Learn more at CBV Test Agency</a>
@@ -442,7 +442,7 @@ en:
         client_comment_title: Client Comments
         consent_checkbox_label_html:
           az_des: Check this box to affirm under penalty of perjury that the information provided by you is true and complete to the best of your knowledge.<ul class="margin-y-2"><li>You agree to tell %{agency_acronym} about:<ul><li>any other income not included in this report,</li><li>or any errors found in the information gathered with this tool.</li></ul></li><li>You understand that providing accurate and complete information is your responsibility.</li><li>Any false or missing information may result in:<ul><li>an overpayment, which you must repay to %{agency_acronym},</li><li>or program disqualification.</li></ul></li></ul>By sending this report, you authorize its use for income verification by %{agency_acronym} and authorized personnel.
-          default: 'Check this box to confirm: <ul class="margin-y-2"><li>The information provided by you is true and complete to the best of your knowledge.</li><li>You agree to inform the %{agency_full_name} (%{agency_acronym}) of any income not reflected in this report or any discrepancies found in the information gathered with this tool.</li><li>You understand that providing accurate and complete information is your responsibility, and any false or omitted information may have legal consequences.</li></ul> By sending this report, you authorize its use for income verification by authorized %{agency_acronym} personnel.'
+          default: 'Check this box to confirm: <ul class="margin-y-2"><li>The information provided by you is true and complete to the best of your knowledge.</li><li>You agree to inform the %{agency_name_with_acronym} of any income not reflected in this report or any discrepancies found in the information gathered with this tool.</li><li>You understand that providing accurate and complete information is your responsibility, and any false or omitted information may have legal consequences.</li></ul> By sending this report, you authorize its use for income verification by authorized %{agency_acronym} personnel.'
           pa_dhs: "<strong>I agree and confirm:</strong><p><strong>I am sharing accurate information.</strong><br>The information I provided is true and complete to the best of my knowledge. I will not share the report if anything in it is incorrect.<p><strong>I will share any missing information.</strong><br>I agree to inform the PA Department of Human Services about any income that is not in this report.<p><strong>I am not sharing false information.</strong><br>I understand that I must share honest information. I understand I could get in legal trouble if I leave out information.<p><strong>I will share my income information.</strong><br>I allow the income information this webpage showed me to be shared with the PA Department of Human Services."
         legal_header: Legal agreement
         none_found: We didn't find any payments from this employer.
@@ -514,7 +514,7 @@ en:
         survey: Take the 5 question survey
         whats_next: What's next?
         whats_next_1_li_1: If you couldn’t find a job or don’t get paystubs, verify your income to %{agency_acronym} online, in person, or by mail.
-        whats_next_1_li_2_html: Go to the <a href="%{agency_website}" target="_blank" rel="noopener noreferrer">%{agency_portal_name} website</a>
+        whats_next_1_li_2_html: Go to %{website_link}
         whats_next_1_title: Verify other income, if needed.
         whats_next_2_li_1_html: We’d like to hear more about your experience using this site.
         whats_next_2_title: Help make this experience better.
@@ -544,7 +544,7 @@ en:
         description: 'We were unable to connect to your employer''s system due to an error. To continue, you can:'
         option_1: Go back to employer search to retry adding this employer.
         option_2: Go back to employer search to add another job.
-        option_3: Submit your income information for this employer by visiting the %{agency_portal_name} website.
+        option_3: Submit your income information for this employer by visiting %{website_label}.
         title: We couldn't access your employer information
     synchronizations:
       indicators:
@@ -561,14 +561,14 @@ en:
       other_ways_no_employer:
         go_to_agency_portal: Go to %{agency_portal_name}
         other_ways_description: 'If there is not another account to log into, you will need to submit income for this job outside of Verify My Income. You can submit the last 30 days of income to %{agency_name} by:'
-        other_ways_option_1_html: Using the document uploader in <a href="%{agency_website}" target="_blank" rel="noopener noreferrer">%{agency_portal_name}</a>.
+        other_ways_option_1_html: Using the document uploader in %{website_link}.
         other_ways_option_2: Mailing or faxing printed income documents
         other_ways_option_3: Taking income documents to a %{agency_acronym} office
         try_searching_again: Try searching again
       other_ways_with_employer:
         continue_to_income_summary: Continue to Income Summary
         more_options: More options
-        more_options_1_html: Using the document uploader in <a href="%{agency_website}" target="_blank" rel="noopener noreferrer">%{agency_portal_name}</a>.
+        more_options_1_html: Using the document uploader in %{website_link}.
         more_options_2: Mailing or faxing printed income documents
         more_options_3: Taking income documents to a %{agency_acronym} office
         more_options_text: 'You can submit the last 30 days of income to %{agency_name} by:'
@@ -765,7 +765,7 @@ en:
       heading: Do you need more time?
     page:
       description: Sessions end after 30 minutes of being away from the page. This helps keep your information safe.
-      info_box_html: To verify your income return to <a href="%{agency_contact_website}" target="_blank" rel="noopener noreferrer">%{agency_portal_name}</a>.
+      info_box_html: To verify your income return to %{website_link}.
       title: Your session has timed out
   shared:
     agency_acronym:
@@ -783,6 +783,10 @@ en:
       la_ldh: LDH
       pa_dhs: COMPASS
       sandbox: VMI
+    # Link/reference text for the agency's website. Partners without a distinct
+    # portal (e.g. Mirza) override this to just their name.
+    agency_website_link_label:
+      default: the %{agency_portal_name} website
     app_name:
       az_des: MyFamilyBenefits
       pa_dhs: VerifyMyIncome

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -212,7 +212,7 @@ es:
         time_estimate: La mayoría de las personas pueden encontrar, conectar y revisar un trabajo en unos 5 minutos.
         what_if_i_cant_use_this_body_1: Si necesita verificar sus ingresos y no puede usar esta herramienta, deberá compartir, de manera directa, la información de sus ingresos para este trabajo con %{agency_portal_name}.
         what_if_i_cant_use_this_body_2_html:
-          default: Para obtener más información sobre cómo enviar documentos, visite el sitio web de <a href="%{agency_url}" target="_blank" rel="noopener noreferrer">%{agency_portal_name}</a>.
+          default: Para obtener más información sobre cómo enviar documentos, visite %{website_link}.
           la_ldh: 'Usted puede: <ul><li>Subir documentos a través del Portal de Autoservicio en línea en <a href="https://mymedicaid.la.gov/" target="_blank" rel="noopener noreferrer">https://mymedicaid.la.gov/</a></li><li>Enviar documentos por correo postal: Louisiana Medicaid/LaCHIP, P.O. Box 91283, Baton Rouge, LA 70821-9278</li><li>Enviar documentos por correo electrónico: <a href="mailto:MyMedicaid@la.gov">MyMedicaid@la.gov</a></li><li>Llevar sus documentos a la oficina de Medicaid de su elección.</li></ul>'
         what_if_i_cant_use_this_title: "¿Qué debo hacer si no puedo usar esta herramienta?"
         what_youll_do: Tres pasos simples
@@ -225,7 +225,7 @@ es:
     error_no_access: No logramos cargar los datos de nómina para esta cuenta. Haga clic en el enlace que recibió de su agencia del SNAP para intentarlo de nuevo.
     expired_invitations:
       show:
-        body_1_html: Si todavía no termina de verificar sus ingresos, envíe su información de ingresos desde el mismo sitio web de <a href="%{agency_url}" target="_blank" rel="noopener noreferrer">%{agency_portal_name}</a>.
+        body_1_html: Si todavía no termina de verificar sus ingresos, envíe su información de ingresos visitando %{website_link}.
         cta_button_html:
           la_ldh: <a href="%{agency_url}" class="usa-button" target="_blank" rel="noopener noreferrer">Visite el sitio web del LDH</a>
           sandbox: <a href="https://www.mass.gov/guides/how-to-contact-dta" class="usa-button" target="_blank" rel="noopener noreferrer">Obtenga más información en la Agencia de pruebas CBV</a>
@@ -335,7 +335,7 @@ es:
         client_comment_title: Comentarios del cliente
         consent_checkbox_label_html:
           az_des: Marque esta casilla para confirmar, bajo pena de perjurio, que la información proporcionada es, a su leal saber y entender, verdadera y está completa.<ul class="margin-y-2"><li>Se compromete a informar %{agency_acronym} de cualquiera de lo siguiente:<ul><li>cualquier otro ingreso que no esté incluido en este informe;</li><li>o cualquier error que haya detectado en la información recopilada con esta herramienta.</li></ul></li><li>Comprende que usted es el único responsable de proporcionar información precisa y completa.</li><li>Por este motivo, cualquier información falsa o que no conste en el informe puede acarrear las siguientes consecuencias:<ul><li>un sobrepago, que debe reembolsar a %{agency_acronym};</li><li>o una inhabilitación para participar en el programa.</li></ul></li></ul>Al enviar este informe, autoriza su uso para fines de verificación de ingresos por parte de %{agency_acronym} y del personal autorizado de esta agencia.
-          default: 'Marque esta casilla para confirmar lo siguiente: <ul class="margin-y-2"><li>La información proporcionada es, a su leal saber y entender, verdadera y está completa.</li><li>Se compromete a informar a %{agency_full_name} (%{agency_acronym}) de cualquier otro ingreso que no esté incluido en este informe o cualquier discrepancia que haya detectado en la información recopilada con esta herramienta.</li><li>Comprende que usted es el único responsable de proporcionar información precisa y completa. Por este motivo, cualquier información falsa o que no conste en el informe puede acarrear consecuencias legales.</li></ul> Al enviar este informe, autoriza su uso para fines de verificación de ingresos por parte del personal autorizado de %{agency_acronym}.'
+          default: 'Marque esta casilla para confirmar lo siguiente: <ul class="margin-y-2"><li>La información proporcionada es, a su leal saber y entender, verdadera y está completa.</li><li>Se compromete a informar a %{agency_name_with_acronym} de cualquier otro ingreso que no esté incluido en este informe o cualquier discrepancia que haya detectado en la información recopilada con esta herramienta.</li><li>Comprende que usted es el único responsable de proporcionar información precisa y completa. Por este motivo, cualquier información falsa o que no conste en el informe puede acarrear consecuencias legales.</li></ul> Al enviar este informe, autoriza su uso para fines de verificación de ingresos por parte del personal autorizado de %{agency_acronym}.'
           pa_dhs: "<strong>Acepto y confirmo que:</strong><br><strong>Compartiré información precisa.</strong> La información que proporcioné es verdadera y completa a mi leal saber y entender. No compartiré el informe si algo en el mismo es incorrecto.<p><strong>Compartiré cualquier información faltante.</strong> Acepto informarle al Departamento de Servicios Humanos de PA sobre los ingresos que no estén en este informe. <p><strong>No compartiré información falsa.</strong> Entiendo que debo compartir información honesta. Entiendo que podría tener problemas legales si omito información.<p><strong>Compartiré la información de mis ingresos.</strong> Autorizo que la información sobre ingresos que me ha mostrado esta página web se comparta con el Departamento de Servicios Humanos de PA."
         legal_header: Acuerdo Legal
         none_found: No encontramos ningún pago de este empleador.
@@ -393,7 +393,7 @@ es:
         survey: Responda esta encuesta de 5 preguntas
         whats_next: "¿Qué sigue?"
         whats_next_1_li_1: Si no pudo encontrar empleo o no tiene recibos de sueldo, verifique sus ingresos en %{agency_acronym} en línea, en persona o por correo.
-        whats_next_1_li_2_html: Visite el <a href="%{agency_website}" target="_blank" rel="noopener noreferrer">sitio web de %{agency_portal_name}</a>
+        whats_next_1_li_2_html: Visite %{website_link}
         whats_next_1_title: Verificar otros ingresos, si es necesario.
         whats_next_2_li_1_html: Nos gustaría saber más sobre su experiencia al usar este sitio.
         whats_next_2_title: Ayude a mejorar esta experiencia.
@@ -423,7 +423,7 @@ es:
         description: 'No pudimos conectarnos al sistema de su empleador debido a un error. Para continuar, puede:'
         option_1: Volver a la búsqueda de empleadores para nuevamente intentar agregar este empleador.
         option_2: Volver a la búsqueda de empleadores para agregar otro trabajo.
-        option_3: Envíe su información de ingresos a este empleador visitando el sitio web de %{agency_portal_name}.
+        option_3: Envíe su información de ingresos a este empleador visitando %{website_label}.
         title: No pudimos acceder a la información de su empleador
     synchronizations:
       indicators:
@@ -440,14 +440,14 @@ es:
       other_ways_no_employer:
         go_to_agency_portal: Ir a %{agency_portal_name}
         other_ways_description: 'Si no hay otra cuenta en la que pueda iniciar sesión, es necesario entregar información de ingresos para este trabajo fuera de Verify My Income. Puede entregar los últimos 30 días de ingresos a %{agency_name}:'
-        other_ways_option_1_html: Usando el cargador de documentos en <a href="%{agency_website}" target="_blank" rel="noopener noreferrer">%{agency_portal_name}</a>.
+        other_ways_option_1_html: Usando el cargador de documentos en %{website_link}.
         other_ways_option_2: Enviando por correo o por fax documentos de ingresos impresos
         other_ways_option_3: Llevando documentos de ingresos a una oficina de %{agency_acronym}
         try_searching_again: Intente buscar de nuevo
       other_ways_with_employer:
         continue_to_income_summary: Continuar al Resumen de Ingresos
         more_options: Más opciones
-        more_options_1_html: Usando el cargador de documentos en <a href="%{agency_website}" target="_blank" rel="noopener noreferrer">%{agency_portal_name}</a>.
+        more_options_1_html: Usando el cargador de documentos en %{website_link}.
         more_options_2: Enviando por correo o por fax documentos de ingresos impresos
         more_options_3: Llevando documentos de ingresos a una oficina de %{agency_acronym}
         more_options_text: 'Puede entregar los últimos 30 días de ingresos a %{agency_name}:'
@@ -688,7 +688,7 @@ es:
       heading: "¿Necesita más tiempo en la sesión?"
     page:
       description: Las sesiones terminan después de 30 minutos de inactividad. Esto ayuda a que su información esté segura.
-      info_box_html: Para verificar sus ingresos, devuélvalo a <a href="%{agency_contact_website}" target="_blank" rel="noopener noreferrer">%{agency_portal_name}</a>.
+      info_box_html: Para verificar sus ingresos, devuélvalo a %{website_link}.
       title: Su sesión ha terminado.
   shared:
     agency_acronym:
@@ -706,6 +706,10 @@ es:
       la_ldh: LDH
       pa_dhs: COMPASS
       sandbox: VMI
+    # Link/reference text for the agency's website. Partners without a distinct
+    # portal (e.g. Mirza) override this to just their name.
+    agency_website_link_label:
+      default: el sitio web de %{agency_portal_name}
     app_name:
       az_des: MyFamilyBenefits
       pa_dhs: VerifyMyIncome

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -707,7 +707,7 @@ es:
       pa_dhs: COMPASS
       sandbox: VMI
     # Link/reference text for the agency's website. Partners without a distinct
-    # portal (e.g. Mirza) override this to just their name.
+    # portal override this to just their name.
     agency_website_link_label:
       default: el sitio web de %{agency_portal_name}
     app_name:

--- a/app/config/routes.rb
+++ b/app/config/routes.rb
@@ -94,6 +94,10 @@ Rails.application.routes.draw do
       scope "/preview", as: :preview do
         root to: "preview#employer_search"
         get "employer_search", to: "preview#employer_search"
+        get "entry", to: "preview#entry"
+        get "expired_invitation", to: "preview#expired_invitation"
+        get "session_timeout", to: "preview#session_timeout"
+        get "success", to: "preview#success"
         get "synchronizations", to: "preview#synchronizations"
         get "synchronization_failures", to: "preview#synchronization_failures"
         get "validation_failures", to: "preview#validation_failures"

--- a/app/db/migrate/20260611000000_add_acronym_and_portal_flags_to_partner_configs.rb
+++ b/app/db/migrate/20260611000000_add_acronym_and_portal_flags_to_partner_configs.rb
@@ -1,0 +1,7 @@
+class AddAcronymAndPortalFlagsToPartnerConfigs < ActiveRecord::Migration[7.2]
+  def change
+    # Default true so existing partners keep their acronym; partners without one
+    # (e.g. Mirza, RealAMI) override to false.
+    add_column :partner_configs, :has_acronym, :boolean, default: true, null: false
+  end
+end

--- a/app/db/migrate/20260611000000_add_acronym_and_portal_flags_to_partner_configs.rb
+++ b/app/db/migrate/20260611000000_add_acronym_and_portal_flags_to_partner_configs.rb
@@ -1,7 +1,7 @@
 class AddAcronymAndPortalFlagsToPartnerConfigs < ActiveRecord::Migration[7.2]
   def change
     # Default true so existing partners keep their acronym; partners without one
-    # (e.g. Mirza, RealAMI) override to false.
+    # override to false.
     add_column :partner_configs, :has_acronym, :boolean, default: true, null: false
   end
 end

--- a/app/db/schema.rb
+++ b/app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_26_155906) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_11_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -135,6 +135,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_26_155906) do
     t.string "state_name"
     t.string "partner_identifier_name"
     t.boolean "include_paystubs", default: false, null: false
+    t.boolean "has_acronym", default: true, null: false
     t.index ["partner_id"], name: "index_partner_configs_on_partner_id", unique: true
   end
 

--- a/app/lib/client_agency_config.rb
+++ b/app/lib/client_agency_config.rb
@@ -148,6 +148,7 @@ class ClientAgencyConfig
       include_paystubs
       state_name
       partner_identifier_name
+      has_acronym
     ])
 
     def initialize(partner_config)
@@ -208,6 +209,8 @@ class ClientAgencyConfig
         partner_config.include_paystubs
       @state_name = partner_config.respond_to?(:state_name) ? partner_config.state_name : nil
       @partner_identifier_name = partner_config.partner_identifier_name
+      # respond_to? guards the pre-migration boot window, like the column guard above.
+      @has_acronym = partner_config.respond_to?(:has_acronym) ? partner_config.has_acronym : true
 
       raise ArgumentError.new("Client Agency missing id") if @id.blank?
       raise ArgumentError.new("Client Agency #{@id} missing required attribute `timezone`") if @timezone.blank?

--- a/app/lib/partner_config_loader.rb
+++ b/app/lib/partner_config_loader.rb
@@ -19,6 +19,7 @@ class PartnerConfigLoader
     weekly_report_enabled weekly_report_recipients weekly_report_variant
     include_invitation_details_on_weekly_report
     partner_identifier_name
+    has_acronym
   ].freeze
 
   REQUIRED_ATTRS = %w[partner_id name timezone pay_income_days_w2 pay_income_days_gig partner_identifier_name].freeze

--- a/app/spec/helpers/application_helper_spec.rb
+++ b/app/spec/helpers/application_helper_spec.rb
@@ -92,6 +92,64 @@ RSpec.describe ApplicationHelper do
     end
   end
 
+  describe "#agency_name_with_acronym" do
+    let(:has_acronym) { true }
+    let(:current_agency) do
+      instance_double(ClientAgencyConfig::ClientAgency, id: "sandbox", has_acronym: has_acronym)
+    end
+
+    before do
+      without_partial_double_verification do
+        allow(helper).to receive(:current_agency).and_return(current_agency)
+      end
+    end
+
+    context "when the partner has an acronym" do
+      it "renders the full name with the acronym in parentheses" do
+        expect(helper.agency_name_with_acronym).to eq("CBV Test Agency (CBV)")
+      end
+    end
+
+    context "when the partner has no acronym" do
+      let(:has_acronym) { false }
+
+      it "renders just the full name, with no parentheses" do
+        expect(helper.agency_name_with_acronym).to eq("CBV Test Agency")
+      end
+    end
+  end
+
+  describe "#agency_website_link" do
+    let(:url) { "https://compass.example.gov" }
+    let(:current_agency) do
+      instance_double(ClientAgencyConfig::ClientAgency, id: "sandbox", agency_contact_website: url)
+    end
+
+    before do
+      without_partial_double_verification do
+        allow(helper).to receive(:current_agency).and_return(current_agency)
+      end
+    end
+
+    it "builds an external link with the configurable label and current markup" do
+      result = helper.agency_website_link
+      expect(result).to include(%(href="#{url}"), 'target="_blank"', 'rel="noopener noreferrer"', "the VMI website")
+      expect(result).to be_html_safe
+    end
+
+    it "uses a custom label when provided" do
+      expect(helper.agency_website_link(label: "Acme")).to include(">Acme</a>")
+    end
+
+    context "when the agency has no website" do
+      let(:url) { nil }
+
+      it "returns the label as plain text with no link" do
+        expect(helper.agency_website_link(label: "Acme")).to eq("Acme")
+      end
+    end
+  end
+
   describe "#feedback_form_url" do
     let(:current_agency) { nil }
     let(:params) { {} }

--- a/docs/app/demo-partner.yml
+++ b/docs/app/demo-partner.yml
@@ -27,6 +27,8 @@ weekly_report_enabled: true
 weekly_report_recipients: test@example.com
 weekly_report_variant: invitations
 include_invitation_details_on_weekly_report: true
+# Set to false for partners with no acronym (e.g. Mirza, RealAMI).
+has_acronym: true
 transmission_methods:
 - method_type: sftp
   configs:

--- a/docs/app/demo-partner.yml
+++ b/docs/app/demo-partner.yml
@@ -27,7 +27,7 @@ weekly_report_enabled: true
 weekly_report_recipients: test@example.com
 weekly_report_variant: invitations
 include_invitation_details_on_weekly_report: true
-# Set to false for partners with no acronym (e.g. Mirza, RealAMI).
+# Set to false for partners with no acronym.
 has_acronym: true
 transmission_methods:
 - method_type: sftp

--- a/docs/app/integration-test-partner.yml
+++ b/docs/app/integration-test-partner.yml
@@ -35,6 +35,7 @@ pay_income_days_gig: 90
 report_customization_show_earnings_list: true
 partner_identifier_name: case_number
 weekly_report_enabled: false
+has_acronym: true
 transmission_methods:
 - method_type: webhook
   configs:


### PR DESCRIPTION
## Summary
Lets partners without an acronym (e.g. Mirza, RealAMI) render their full agency name with no awkward parenthetical, and centralizes the agency website link into a single configurable helper instead of hand-written `<a>` markup scattered across the CBV flow.

## Type of Change
Check all that apply.
- [ ] Bug
- [x] Feature
- [x] Refactor
- [ ] Documentation update

## Changes
- Add a `has_acronym` flag to `PartnerConfig` (migration + `ClientAgencyConfig` + `PartnerConfigLoader`); `agency_name_with_acronym` helper drops the `(ACRONYM)` parenthetical for partners without one (e.g. the consent label).
- Add an `agency_website_link` helper + configurable `shared.agency_website_link_label`, replacing inline `<a>` markup in the entry, expired-invitation, success, session-timeout, sync-failure, and validation-failure strings (en + es). Markup is unchanged; partners override the label (e.g. Mirza → "Mirza").
- Add preview routes/actions for the entry, expired-invitation, session-timeout, and success pages, with nav entries in the preview bar.

## Checklist
- [x] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
- Accessibility of the website links (no "opens in a new tab" affordance, hand-maintained `rel`) was intentionally left unchanged for now — centralizing into one helper makes that a future one-line fix.
- The `respond_to?` guard on `has_acronym` matches the existing `include_paystubs`/`state_name` pattern for the pre-migration boot window.