### PR TITLE
feat(integration): make webhook spec runnable against partner environments

### DIFF
--- a/app/docs/integration-tests.md
+++ b/app/docs/integration-tests.md
@@ -71,6 +71,40 @@ Integration specs carry the tag `integration: true` and are excluded from the de
 | `unencrypted_s3_transmitter_integration_spec.rb` | `UnencryptedS3Transmitter` | s3proxy (port 9000) |
 | `encrypted_s3_transmitter_integration_spec.rb` | `EncryptedS3Transmitter` | s3proxy (port 9000) + locally generated GPG keypair |
 
+## Running the webhook spec against a customer environment
+
+The webhook integration spec can also run against a **partner's** webhook endpoint instead of the local reference server. This is a conformance check: it verifies that our outbound payload, request signing (`X-VMI-*` headers, HMAC-SHA512), and error handling are compatible with a receiver the partner built independently from our contract.
+
+It is the same spec — only the target and a few inputs change, supplied via environment variables:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `WEBHOOK_TEST_URL` | `http://localhost:9292/api/v1/income-report` | Full endpoint URL, **including path**. Point this at the partner's host. |
+| `WEBHOOK_TEST_API_KEY` | `my-secure-guid` | API key used for the `X-VMI-API-Key` header and the HMAC signature. |
+| `WEBHOOK_TEST_CLIENT_INFORMATION` | `case_number=ABC1234` | Comma-separated `key=value` pairs sent in the payload's `client_information` block. Values are sent verbatim, so you can match a partner's expected custom attributes. |
+| `WEBHOOK_TEST_DEBUG` | _(unset)_ | When set, logs each request's outbound payload and the server's raw response (status + body), and enables an extra diagnostic example. Off by default so CI output stays clean. |
+
+No Docker reference server is needed when targeting a partner — you hit their host directly. The spec turns VCR off and allows real network connections automatically, so HTTPS endpoints behave the same as the local HTTP one.
+
+Run it inside the app container, against the partner's QA:
+
+```bash
+docker compose run --rm \
+  -e RAILS_ENV=test \
+  -e INTEGRATION_RUN_TESTS=1 \
+  -e WEBHOOK_TEST_URL="https://partner-host/their/path" \
+  -e WEBHOOK_TEST_API_KEY="<partner key>" \
+  -e WEBHOOK_TEST_CLIENT_INFORMATION="case_number=ABC1234" \
+  -e WEBHOOK_TEST_DEBUG=1 \
+  app_rails bundle exec rspec spec/services/transmitters/webhook_transmitter_integration_spec.rb
+```
+
+- `RAILS_ENV=test` is **required** — the compose service defaults to `development`, where Factory Bot is not loaded (you'd get `uninitialized constant FactoryBot`).
+- `INTEGRATION_RUN_TESTS=1` un-skips the `integration: true` tag when invoking `rspec` directly. (The `integration:rspec:*` rake tasks already pass `--tag integration`, so they don't need it.)
+- If a gem was added/bumped since the image was last built, rebuild first with `docker compose build app_rails`.
+
+**Interpreting failures:** the assertions are strict and faithful to our published contract — status codes *and* error-envelope shape (e.g. `error_code: "VALIDATION_ERROR"`, `AUTHENTICATION_ERROR`). The local reference server matches the contract, so CI stays green. A partner's independent implementation may diverge; when it does, the failures are **conformance findings to reconcile with the partner**, not bugs in the test. Use `WEBHOOK_TEST_DEBUG=1` to capture the exact request/response for those conversations.
+
 ## End-to-End Browser Testing (optional)
 
 The `integration:partner:setup` task creates an `integration_test` partner and a service-account user with an API access token. This lets you exercise the full CBV flow end-to-end through a browser, with real webhook delivery to the Docker services.

--- a/app/spec/services/transmitters/webhook_transmitter_integration_spec.rb
+++ b/app/spec/services/transmitters/webhook_transmitter_integration_spec.rb
@@ -14,8 +14,19 @@ RSpec.describe Transmitters::WebhookTransmitter, integration: true do
     )
   end
 
-  let(:webhook_url) { "http://localhost:9292/api/v1/income-report" }
+  let(:webhook_url) { ENV.fetch("WEBHOOK_TEST_URL", "http://localhost:9292/api/v1/income-report") }
   let(:api_key) { ENV.fetch("WEBHOOK_TEST_API_KEY", "my-secure-guid") }
+
+  # The client_information custom attributes (name => value) to include in the
+  # payload. Configurable via WEBHOOK_TEST_CLIENT_INFORMATION as comma-separated
+  # key=value pairs, e.g.
+  #   WEBHOOK_TEST_CLIENT_INFORMATION="case_number=ABC1234,first_name=John"
+  let(:custom_attributes) do
+    ENV.fetch("WEBHOOK_TEST_CLIENT_INFORMATION", "case_number=ABC1234")
+       .split(",")
+       .map { |pair| pair.split("=", 2).map(&:strip) }
+       .to_h
+  end
   let(:transmission_method_configuration) do
     {
       "webhook_url" => webhook_url,
@@ -45,13 +56,37 @@ RSpec.describe Transmitters::WebhookTransmitter, integration: true do
     allow(mock_client_agency).to receive(:timezone).and_return("America/New_York")
     allow(mock_client_agency).to receive(:transmission_methods).and_return(configured_methods)
     allow(mock_client_agency).to receive(:include_paystubs).and_return(false)
-    allow(CbvApplicant).to receive(:valid_attributes_for_agency).with("sandbox").and_return([ "case_number" ])
+    allow(CbvApplicant).to receive(:valid_attributes_for_agency).with("sandbox").and_return(custom_attributes.keys.map(&:to_sym))
+    # Return the configured name => value pairs verbatim (string keys, matching
+    # the real build_custom_attributes), bypassing the cbv_applicant factory.
+    allow(CbvApplicant).to receive(:build_custom_attributes).with("sandbox").and_return(custom_attributes)
 
+    # This is a live integration test (no cassettes). VCR is hooked into
+    # WebMock globally and blocks un-cassetted requests to non-ignored hosts
+    # (localhost is ignored, which is why the default reference server works
+    # but a real host does not), so turn VCR off and allow real connections.
+    VCR.turn_off!(ignore_cassettes: true)
     WebMock.allow_net_connect!
+
+    # DIAGNOSTIC (opt-in via WEBHOOK_TEST_DEBUG): log the server response for
+    # every request the suite makes, regardless of whether the example calls
+    # #deliver (which raises and only logs the body) or posts directly. Lets us
+    # see the response code/body for each scenario in one run. Off in CI.
+    if ENV["WEBHOOK_TEST_DEBUG"].present?
+      allow_any_instance_of(Net::HTTP).to receive(:request).and_wrap_original do |original, *args, &block|
+        original.call(*args, &block).tap do |res|
+          puts "\n----- DIAGNOSTIC server response -----"
+          puts "HTTP #{res.code} #{res.message}"
+          puts "Body: #{res.body.inspect}"
+          puts "-----------------------------------------------------"
+        end
+      end
+    end
   end
 
   after do
     WebMock.disable_net_connect!
+    VCR.turn_on!
   end
 
   subject { described_class.new(cbv_flow, mock_client_agency, aggregator_report, transmission_method_configuration) }
@@ -62,6 +97,34 @@ RSpec.describe Transmitters::WebhookTransmitter, integration: true do
     it "successfully delivers to a running reference server" do
       result = subject.deliver
       expect(result).to eq("ok")
+    end
+
+    # Diagnostic (opt-in via WEBHOOK_TEST_DEBUG): posts the happy-path payload
+    # and prints exactly what we sent and what the server returned. Useful when
+    # the sunny-day delivery fails (e.g. a 400) and you need to see the server's
+    # validation message. Skipped in CI.
+    it "DIAGNOSTIC: prints the request payload and server response", if: ENV["WEBHOOK_TEST_DEBUG"].present? do
+      uri = URI(webhook_url)
+      body = CbvFlowToJson.new(cbv_flow, mock_client_agency, aggregator_report).to_h.to_json
+
+      req = Net::HTTP::Post.new(uri)
+      req.content_type = "application/json"
+      req.body = body
+      timestamp = Time.now.to_i.to_s
+      req["X-VMI-Timestamp"] = timestamp
+      req["X-VMI-Signature"] = JsonApiSignature.generate(body, timestamp, api_key)
+      req["X-VMI-API-Key"] = api_key
+      req["X-VMI-Confirmation-Code"] = cbv_flow.confirmation_code
+
+      res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == "https") { |http| http.request(req) }
+
+      puts "\n===== DIAGNOSTIC: outbound request ====="
+      puts "POST #{uri}"
+      puts JSON.pretty_generate(JSON.parse(body))
+      puts "===== DIAGNOSTIC: server response ====="
+      puts "HTTP #{res.code} #{res.message}"
+      puts "Body: #{res.body.inspect}"
+      puts "=======================================\n"
     end
 
     it "sends a valid JSON payload with expected top-level keys" do
@@ -163,7 +226,7 @@ RSpec.describe Transmitters::WebhookTransmitter, integration: true do
       req["X-VMI-API-Key"] = api_key
       req["X-VMI-Confirmation-Code"] = cbv_flow.confirmation_code
 
-      res = Net::HTTP.start(uri.hostname, uri.port) { |http| http.request(req) }
+      res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == "https") { |http| http.request(req) }
 
       expect(res.code).to eq("400")
       error_body = JSON.parse(res.body)
@@ -189,7 +252,7 @@ RSpec.describe Transmitters::WebhookTransmitter, integration: true do
       req["X-VMI-API-Key"] = wrong_key
       req["X-VMI-Confirmation-Code"] = cbv_flow.confirmation_code
 
-      res = Net::HTTP.start(uri.hostname, uri.port) { |http| http.request(req) }
+      res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == "https") { |http| http.request(req) }
 
       expect(res.code).to eq("401")
       error_body = JSON.parse(res.body)


### PR DESCRIPTION
## Summary
Enables the webhook integration spec to run against a partner's live endpoint (not just the local reference server), supporting QA conformance testing against independently-built webhook receivers.

## Type of Change
- [ ] Bug
- [x] Feature
- [ ] Refactor
- [x] Documentation update

## Changes
- Add `WEBHOOK_TEST_URL` env var override so the spec can target any endpoint (defaults to `localhost:9292`)
- Add `WEBHOOK_TEST_CLIENT_INFORMATION` for configuring `client_information` custom attributes per partner (e.g. `case_number=ABC1234,correlation_id=XYZ`)
- Add `WEBHOOK_TEST_DEBUG` flag for opt-in per-request diagnostic logging and an extra diagnostic example — off in CI, useful when debugging a partner's 400 response
- Fix `use_ssl` missing from two hand-rolled `Net::HTTP.start` calls (tests couldn't speak HTTPS to real partner endpoints)
- Disable VCR for live runs (`VCR.turn_off!` / `VCR.turn_on!` in before/after hooks) — previously only `localhost` was exempted, blocking any non-localhost host
- Document the full partner-testing workflow in `docs/integration-tests.md`

## Checklist
- [x] Tests added/updated (if needed)
- [x] Docs updated (if needed)

## Notes for Reviewers
The strict error-envelope assertions (`error_code: "VALIDATION_ERROR"`, `AUTHENTICATION_ERROR`) are intentionally kept. CI runs against the reference server (green); failures against a partner are conformance findings, not test bugs. The `WEBHOOK_TEST_DEBUG` flag is the tool for capturing evidence for those conversations.