### PR TITLE
PF-642: Dynamic Route Loading

### DIFF
--- a/app/Gemfile
+++ b/app/Gemfile
@@ -107,6 +107,9 @@ group :development do
   gem "rails-erd", "~> 1.7"
 end
 
+# Realistic fake data, used by the dev-only partner generator rake task.
+gem "faker", "~> 3.5", group: %i[development test]
+
 group :test do
   gem "pdf-reader", "~> 2.15.0"
   gem "axe-core-rspec", "~> 4.10"

--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -219,6 +219,8 @@ GEM
     erubi (1.13.1)
     factory_bot (6.5.6)
       activesupport (>= 6.1.0)
+    faker (3.8.0)
+      i18n (>= 1.8.11, < 2)
     faraday (2.14.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
@@ -619,6 +621,7 @@ DEPENDENCIES
   dotenv-rails (~> 2.7)
   erb_lint
   factory_bot (~> 6.5)
+  faker (~> 3.5)
   faraday (~> 2.13)
   gpgme (~> 2.0, >= 2.0.12)
   i18n-tasks (~> 1.0)

--- a/app/app/controllers/application_controller.rb
+++ b/app/app/controllers/application_controller.rb
@@ -86,10 +86,8 @@ class ApplicationController < ActionController::Base
     host = request.host
     subdomain = host.split(".").first
 
-    agency_config.client_agency_ids.find do |agency_id|
-      agency = agency_config[agency_id]
-      agency.agency_domain == subdomain || agency.agency_domain == host
-    end
+    agency = agency_config.find_by_domain(subdomain) || agency_config.find_by_domain(host)
+    agency&.id
   end
 
   def pilot_ended?

--- a/app/app/controllers/caseworker/base_controller.rb
+++ b/app/app/controllers/caseworker/base_controller.rb
@@ -1,4 +1,5 @@
 class Caseworker::BaseController < ApplicationController
+  before_action :ensure_known_agency
   before_action :redirect_if_disabled
 
   def authenticate_user!
@@ -17,5 +18,16 @@ class Caseworker::BaseController < ApplicationController
         slim_alert: { message: I18n.t("caseworker.entries.disabled"), type: "error" }
       }
     end
+  end
+
+  private
+
+  # Partner routes are validated dynamically by ClientAgencyIdConstraint, so a
+  # request only reaches here for a known partner. This is defense-in-depth for
+  # any path that bypasses routing (e.g. direct controller invocation): an
+  # unknown partner has no route, so treat it as a 404 rather than blowing up on
+  # a nil agency.
+  def ensure_known_agency
+    raise ActionController::RoutingError, "No partner configured for #{params[:client_agency_id].inspect}" if current_agency.nil?
   end
 end

--- a/app/app/helpers/application_helper.rb
+++ b/app/app/helpers/application_helper.rb
@@ -19,6 +19,12 @@ module ApplicationHelper
   # is either missing or there is no current client agency, it will attempt to render a
   # "default" key.
   def agency_translation(i18n_base_key, **options)
+    # Relative (leading-dot) keys are scoped to the current template's path.
+    # Expand them up front so the database lookup — which stores full keys like
+    # "cbv.entries.show.checkbox" — can match. Without this, DB overrides
+    # silently fail for relative-key call sites and the YAML value is always used.
+    i18n_base_key = scope_key_by_partial(i18n_base_key) if i18n_base_key.start_with?(".")
+
     if i18n_base_key.include?("{agency}")
       i18n_key = current_agency ? i18n_base_key.gsub("{agency}", current_agency.id) : nil
       default_key = i18n_base_key.gsub("{agency}", "default")
@@ -123,7 +129,7 @@ module ApplicationHelper
     locale = I18n.locale.to_s
     cache_key = PartnerTranslation.cache_key_for(partner_config.id, locale, base_key)
 
-    value = Rails.cache.fetch(cache_key, expires_in: 10.minutes) do
+    value = fetch_translation_cache(cache_key) do
       translation = PartnerTranslation.find_by(
         partner_config: partner_config,
         locale: locale,
@@ -162,9 +168,21 @@ module ApplicationHelper
   end
 
   def cached_partner_config(partner_id)
-    Rails.cache.fetch("partner_config/#{partner_id}", expires_in: 10.minutes) do
+    fetch_translation_cache("partner_config/#{partner_id}") do
       PartnerConfig.find_by(partner_id: partner_id)
     end
+  end
+
+  TRANSLATION_CACHE_TTL = 10.minutes
+
+  # Caches DB-backed partner config/translation lookups, except in development
+  # where the cache is bypassed so edits made directly in the database show up
+  # immediately on refresh (a direct DB edit never fires the model's
+  # expire_cache callback). Mirrors ClientAgencyConfig's dev-immediate behavior.
+  def fetch_translation_cache(cache_key, &block)
+    return block.call if Rails.env.development?
+
+    Rails.cache.fetch(cache_key, expires_in: TRANSLATION_CACHE_TTL, &block)
   end
 
   public

--- a/app/config/initializers/validate_partner_configs.rb
+++ b/app/config/initializers/validate_partner_configs.rb
@@ -17,6 +17,7 @@ Rails.application.config.after_initialize do
   begin
     ClientAgencyConfig.instance.validate_all
   rescue => e
-    Rails.logger.warn("Skipped partner config validation at boot: #{e.message}")
+    Rails.logger.error("Skipped partner config validation at boot: #{e.message}")
+    NewRelic::Agent.notice_error(e) if defined?(NewRelic::Agent)
   end
 end

--- a/app/config/initializers/validate_partner_configs.rb
+++ b/app/config/initializers/validate_partner_configs.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Partner configs are loaded lazily per request (see ClientAgencyConfig), so
+# nothing is loaded into memory at boot. We still run a single validation pass at
+# boot to surface any misconfigured partner early — partner configs change
+# rarely, so this is a cheap diagnostic, not a serving cost. It only logs
+# warnings (it never raises), so one broken partner can't take down boot. Live
+# requests independently re-validate the specific partner being served (see
+# ClientAgencyConfig#build_agency), so partners changed after boot are still
+# caught.
+#
+# Skipped in the test environment, where validation is exercised directly in
+# specs and a boot-time pass would only add log noise.
+Rails.application.config.after_initialize do
+  next if Rails.env.test?
+
+  begin
+    ClientAgencyConfig.instance.validate_all
+  rescue => e
+    Rails.logger.warn("Skipped partner config validation at boot: #{e.message}")
+  end
+end

--- a/app/config/routes.rb
+++ b/app/config/routes.rb
@@ -1,5 +1,6 @@
 
 require "constraints/configured_agency_constraint"
+require "constraints/client_agency_id_constraint"
 
 Rails.application.routes.draw do
   devise_for :users,
@@ -74,15 +75,11 @@ Rails.application.routes.draw do
       resource :expired_invitation, only: %i[show]
       resource :applicant_information, only: %i[show update]
 
-      # Generic link
-      begin
-        if ActiveRecord::Base.connection.data_source_exists?(:partner_application_attributes)
-          scope "links/:client_agency_id", constraints: { client_agency_id: Regexp.union(ClientAgencyConfig.client_agency_ids) } do
-            root to: "generic_links#show", as: :new
-          end
-        end
-      rescue ActiveRecord::NoDatabaseError, PG::ConnectionBad, ActiveRecord::ConnectionNotEstablished, ArgumentError
-        # The database hasn't been created yet, we are likely in a db task.
+      # Generic link. The client_agency_id segment is validated dynamically per
+      # request against the database (see ClientAgencyIdConstraint), so partners
+      # are not enumerated into the route table at boot.
+      scope "links/:client_agency_id", constraints: ClientAgencyIdConstraint.new do
+        root to: "generic_links#show", as: :new
       end
 
       # Session management
@@ -114,21 +111,16 @@ Rails.application.routes.draw do
       end
     end
 
-    # This code runs during every boot of the app, including the migrations necessary to create the partner_configs table.
-    # Skip if the table hasn't been created yet.
-    # The partner application attributes are added last, so if they are not present, the db is missing tables needed to initialize from db configuration.
-    begin
-      if ActiveRecord::Base.connection.data_source_exists?(:partner_application_attributes)
-        scope "/:client_agency_id", module: :caseworker, constraints: { client_agency_id: Regexp.union(ClientAgencyConfig.client_agency_ids) } do
-          get "/sso", to: redirect("/%{client_agency_id}") # Temporary: Remove once people get used to going to /:client_agency_id as the login destination.
-          root to: "entries#index", as: :new_user_session
+    # Caseworker portal, scoped per partner. The client_agency_id segment is
+    # validated dynamically per request against the database (see
+    # ClientAgencyIdConstraint) rather than enumerating partners into the route
+    # table at boot.
+    scope "/:client_agency_id", module: :caseworker, constraints: ClientAgencyIdConstraint.new do
+      get "/sso", to: redirect("/%{client_agency_id}") # Temporary: Remove once people get used to going to /:client_agency_id as the login destination.
+      root to: "entries#index", as: :new_user_session
 
-          resource :dashboard, only: %i[show], as: :caseworker_dashboard
-          resources :cbv_flow_invitations, only: %i[new create], as: :invitations, path: :invitations
-        end
-      end
-    rescue ActiveRecord::NoDatabaseError, PG::ConnectionBad, ActiveRecord::ConnectionNotEstablished, ArgumentError
-      # The database hasn't been created yet, we are likely in a db task.
+      resource :dashboard, only: %i[show], as: :caseworker_dashboard
+      resources :cbv_flow_invitations, only: %i[new create], as: :invitations, path: :invitations
     end
   end
 

--- a/app/lib/client_agency_config.rb
+++ b/app/lib/client_agency_config.rb
@@ -15,6 +15,13 @@ class ClientAgencyConfig
   # 'ninety_days'/'six_months' to see other places you will need to customize.
   VALID_PAY_INCOME_DAYS = [ 90, 182 ]
 
+  # How long a hydrated agency stays cached before it is reloaded from the
+  # database. Bounds how stale a config can be: changes made to partner_configs
+  # while the app is running are picked up within this window without a restart.
+  # In development the effective TTL is 0 so edits show up immediately (see
+  # #cache_ttl_seconds).
+  CACHE_TTL_SECONDS = 5.minutes.to_i
+
   def self.instance
     @instance ||= new(Rails.env.development? || Rails.env.test?)
   end
@@ -31,51 +38,156 @@ class ClientAgencyConfig
     instance.client_agency_ids
   end
 
-  def client_agency_ids
-    (@client_agencies || {}).keys
-  end
-
-  def [](client_agency_id)
-    (@client_agencies || {})[client_agency_id]
-  end
-
   def initialize(load_all_agency_configs)
-    # This runs during bootup even before migrations. this is a temp guard until these migrations are made
-    # TODO: make this less brittle
-    # This should be resolved by dynamic partner load, PF-642
-    return unless ActiveRecord::Base.connection.column_exists?(:partner_configs, :include_full_ssn)
+    @load_all_agency_configs = load_all_agency_configs
+    # Configs are loaded lazily, per-agency, the first time each one is requested
+    # (see #[]). Nothing is loaded at boot. Each cache holds timestamped entries
+    # that expire after CACHE_TTL_SECONDS so DB changes are picked up at runtime.
+    # @agencies caches hydrated agencies by partner_id; @domain_index caches
+    # resolved domain => partner_id lookups.
+    @agencies = {}
+    @domain_index = {}
+  end
 
-    @client_agencies = PartnerConfig.all.each_with_object({}) do |config, h|
-      next unless load_all_agency_configs ||
-        (config.active_demo? && demo_mode?) ||
-        (config.active_prod? && Rails.env.production?)
-      h[config.partner_id] = ClientAgency.new(config)
+  # Lazily loads and caches a single agency by partner_id, based on the
+  # client_agency_id present in the requested URL. The cached entry is reloaded
+  # from the database once it is older than CACHE_TTL_SECONDS, so edits to the
+  # partner config (or a partner being deactivated/removed) are reflected within
+  # that window without a restart.
+  #
+  # Returns nil when the partner does not exist, is not active in this
+  # environment, or fails hard validation (in which case a warning is logged so a
+  # single broken partner can't crash the request). Misses are not cached.
+  def [](client_agency_id)
+    return nil if client_agency_id.blank?
+
+    entry = @agencies[client_agency_id]
+    return entry[:agency] if entry && fresh?(entry)
+    return nil unless db_ready?
+
+    config = PartnerConfig.find_by(partner_id: client_agency_id)
+    unless config && active_in_current_environment?(config)
+      @agencies.delete(client_agency_id)
+      return nil
     end
 
-    validate_partner_application_attributes
+    agency = build_agency(config)
+    if agency.nil?
+      @agencies.delete(client_agency_id)
+      return nil
+    end
+
+    @agencies[client_agency_id] = { agency: agency, loaded_at: now }
+    agency
   end
 
-  # TODO: Possibly remove, this appears unused.
-  # def self.client_agencies(load_all_agency_configs = false)
-  #   self.client_agency_ids(load_all_agency_configs)
-  # end
+  # Resolves an agency by its configured subdomain/host slug (e.g. "pa" or
+  # "pa.example.com"). A single indexed lookup (cached with the same TTL as #[]),
+  # then delegates to #[] for hydration.
+  def find_by_domain(domain)
+    return nil if domain.blank?
+    return nil unless db_ready?
+
+    entry = @domain_index[domain]
+    if entry && fresh?(entry)
+      partner_id = entry[:partner_id]
+    else
+      config = PartnerConfig.find_by(domain: domain)
+      unless config && active_in_current_environment?(config)
+        @domain_index.delete(domain)
+        return nil
+      end
+
+      partner_id = config.partner_id
+      @domain_index[domain] = { partner_id: partner_id, loaded_at: now }
+    end
+
+    self[partner_id]
+  end
+
+  def client_agency_ids
+    active_partner_configs.pluck(:partner_id)
+  end
+
+  # Eagerly validates every active partner config WITHOUT caching them for
+  # serving, so a single boot-time pass surfaces misconfiguration early. Logs (but
+  # does not raise on) any partner that fails to construct or is missing required
+  # configuration, so one bad partner can't take down boot. Run from the
+  # validate_partner_configs initializer; serving stays lazy via #[].
+  def validate_all
+    return unless db_ready?
+
+    active_partner_configs.find_each { |config| validate_config(config) }
+  end
 
   private
 
-  def validate_partner_application_attributes
-    return unless @client_agencies.present?
+  # A cache entry is fresh until it is older than the TTL, after which the next
+  # lookup reloads it from the database.
+  def fresh?(entry)
+    now - entry[:loaded_at] < cache_ttl_seconds
+  end
 
-    @client_agencies.each do |partner_id, agency|
-      if agency.applicant_attributes.empty?
-        message = "Partner #{partner_id} has no partner_application_attributes configured. " \
-          "API metadata will be silently dropped and data retention will fail."
-        Rails.logger.error(message)
-        NewRelic::Agent.notice_error(StandardError.new(message)) if defined?(NewRelic::Agent)
-      end
+  # Effective cache TTL. In development it is 0 so every lookup reloads from the
+  # database and config edits are reflected immediately; elsewhere it is the full
+  # CACHE_TTL_SECONDS.
+  def cache_ttl_seconds
+    Rails.env.development? ? 0 : CACHE_TTL_SECONDS
+  end
+
+  # Monotonic clock (seconds) so cache expiry is unaffected by wall-clock changes.
+  def now
+    Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  end
+
+  def active_partner_configs
+    return PartnerConfig.none unless db_ready?
+
+    if @load_all_agency_configs
+      PartnerConfig.all
+    elsif demo_mode?
+      PartnerConfig.where(active_demo: true)
+    elsif Rails.env.production?
+      PartnerConfig.where(active_prod: true)
+    else
+      PartnerConfig.none
+    end
+  end
+
+  def active_in_current_environment?(config)
+    @load_all_agency_configs ||
+      (config.active_demo? && demo_mode?) ||
+      (config.active_prod? && Rails.env.production?)
+  end
+
+  # Builds and validates a single agency for serving. A hard-validation failure
+  # is converted to a logged warning + nil rather than a raised exception, so a
+  # broken partner config yields a 404 (route won't match) instead of a 500.
+  def build_agency(config)
+    agency = ClientAgency.new(config)
+    warn_on_soft_validation(config, agency)
+    agency
+  rescue ArgumentError => e
+    report_partner_error("Partner #{config.partner_id} failed validation and is unavailable: #{e.message}")
+    nil
+  end
+
+  # Boot-time counterpart to #build_agency: surfaces both hard and soft problems
+  # as log warnings without building anything for serving.
+  def validate_config(config)
+    agency = ClientAgency.new(config)
+    warn_on_soft_validation(config, agency)
+  rescue ArgumentError => e
+    report_partner_error("Partner #{config.partner_id} failed validation: #{e.message}")
+  end
+
+  def warn_on_soft_validation(config, agency)
+    if agency.applicant_attributes.empty?
+      report_partner_error("Partner #{config.partner_id} has no partner_application_attributes configured. " \
+        "API metadata will be silently dropped and data retention will fail.")
     end
 
-    validate_partner_translations if defined?(::PartnerTranslation) &&
-      ActiveRecord::Base.connection.data_source_exists?(:partner_translations)
+    validate_partner_translations(config)
   end
 
   REQUIRED_TRANSLATION_KEYS = %w[
@@ -88,34 +200,46 @@ class ClientAgencyConfig
       shared.agency_acronym
     ].freeze
 
-  def validate_partner_translations
-    return unless @client_agencies.present?
+  def validate_partner_translations(config)
+    return unless defined?(::PartnerTranslation) &&
+      ActiveRecord::Base.connection.data_source_exists?(:partner_translations)
 
-    @client_agencies.each do |partner_id, _agency|
-      config = PartnerConfig.find_by(partner_id: partner_id)
-      next unless config
+    partner_id = config.partner_id
+    %w[en es].each do |locale|
+      REQUIRED_TRANSLATION_KEYS.each do |base_key|
+        full_key = "#{base_key}.#{partner_id}"
+        has_db = ::PartnerTranslation.exists?(partner_config: config, locale: locale, key: base_key) ||
+          ::PartnerTranslation.exists?(partner_config: config, locale: locale, key: full_key)
+        has_locale = I18n.exists?(full_key, locale.to_sym)
+        next if has_db || has_locale
 
-      %w[en es].each do |locale|
-        REQUIRED_TRANSLATION_KEYS.each do |base_key|
-          full_key = "#{base_key}.#{partner_id}"
-          has_db = ::PartnerTranslation.exists?(partner_config: config, locale: locale, key: base_key) ||
-            ::PartnerTranslation.exists?(partner_config: config, locale: locale, key: full_key)
-          has_locale = I18n.exists?(full_key, locale.to_sym)
+        default_key = "#{base_key}.default"
+        has_db_default = ::PartnerTranslation.exists?(partner_config: config, locale: locale, key: default_key)
+        has_locale_default = I18n.exists?(default_key, locale.to_sym)
+        next if has_db_default || has_locale_default
 
-          unless has_db || has_locale
-            default_key = "#{base_key}.default"
-            has_db_default = ::PartnerTranslation.exists?(partner_config: config, locale: locale, key: default_key)
-            has_locale_default = I18n.exists?(default_key, locale.to_sym)
-
-            unless has_db_default || has_locale_default
-              message = "Partner #{partner_id} missing translation: #{full_key} (#{locale}) with no default fallback"
-              Rails.logger.warn(message)
-              NewRelic::Agent.notice_error(StandardError.new(message)) if defined?(NewRelic::Agent)
-            end
-          end
-        end
+        report_partner_warning("Partner #{partner_id} missing translation: #{full_key} (#{locale}) with no default fallback")
       end
     end
+  end
+
+  # Guards the lazy DB lookups: the table/column checks tolerate boot-time and
+  # rake-task scenarios where the schema isn't ready yet (migrations, db:create).
+  def db_ready?
+    ActiveRecord::Base.connection.data_source_exists?(:partner_application_attributes) &&
+      ActiveRecord::Base.connection.column_exists?(:partner_configs, :partner_identifier_name)
+  rescue ActiveRecord::NoDatabaseError, PG::ConnectionBad, ActiveRecord::ConnectionNotEstablished, ActiveRecord::StatementInvalid
+    false
+  end
+
+  def report_partner_error(message)
+    Rails.logger.error(message)
+    NewRelic::Agent.notice_error(StandardError.new(message)) if defined?(NewRelic::Agent)
+  end
+
+  def report_partner_warning(message)
+    Rails.logger.warn(message)
+    NewRelic::Agent.notice_error(StandardError.new(message)) if defined?(NewRelic::Agent)
   end
 
   public

--- a/app/lib/client_agency_config.rb
+++ b/app/lib/client_agency_config.rb
@@ -20,7 +20,7 @@ class ClientAgencyConfig
   # while the app is running are picked up within this window without a restart.
   # In development the effective TTL is 0 so edits show up immediately (see
   # #cache_ttl_seconds).
-  CACHE_TTL_SECONDS = 5.minutes.to_i
+  CACHE_TTL_SECONDS = 10.minutes.to_i
 
   def self.instance
     @instance ||= new(Rails.env.development? || Rails.env.test?)

--- a/app/lib/constraints/client_agency_id_constraint.rb
+++ b/app/lib/constraints/client_agency_id_constraint.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Routing constraint that validates the `:client_agency_id` URL segment at
+# request time instead of baking the set of known partners into the route table
+# at boot.
+class ClientAgencyIdConstraint
+  def matches?(request)
+    client_agency_id = request.path_parameters[:client_agency_id]
+    client_agency_id.present? && ClientAgencyConfig.instance[client_agency_id].present?
+  end
+end

--- a/app/lib/constraints/configured_agency_constraint.rb
+++ b/app/lib/constraints/configured_agency_constraint.rb
@@ -21,12 +21,10 @@ class ConfiguredAgencyConstraint
     labels.first # host
   end
 
-  # determine if the subdomain represents a configured agency
+  # determine if the subdomain represents a configured agency.
+  # Uses a single indexed lookup (cached in ClientAgencyConfig) by domain rather than scanning every partner,
+  # so this runs cheaply on the redirect hot path without loading all configs.
   def configured_agency?(slug)
-    cfg = ClientAgencyConfig.instance
-    cfg.client_agency_ids.any? do |id|
-      agency = cfg[id]
-      agency.agency_domain.to_s == slug
-    end
+    ClientAgencyConfig.instance.find_by_domain(slug).present?
   end
 end

--- a/app/lib/tasks/dev_partner.rake
+++ b/app/lib/tasks/dev_partner.rake
@@ -1,0 +1,253 @@
+# Dev-only helper to spin up a fully-formed partner (config + transmission
+# method + application attributes + DB translations) populated with realistic
+# fake data).
+#
+#   bundle exec rake dev:partner:create
+#   bundle exec rake "dev:partner:create[my_partner_id]"
+#   bundle exec rake "dev:partner:destroy[my_partner_id]"
+#   bundle exec rake dev:partner:list
+#
+# Copies a reference agency's translations onto a new partner so it renders
+# everywhere — not just the handful of keys validated at boot. Agency-specific
+# strings live in the locale files keyed by agency id, in two shapes:
+#   1. suffix:  shared.agency_portal_name: { sandbox: "...", pa_dhs: "..." }
+#   2. subtree: cbv.applicant_informations: { sandbox: { fields: {...} }, ... }
+# We walk the loaded I18n tree for the reference agency and re-key its values for
+# the new partner so db_translation finds them.
+module DevPartnerTranslations
+  module_function
+
+  # => { locale_sym => { db_key => value } }
+  def for_partner(partner_id, reference: "sandbox")
+    I18n.backend.send(:init_translations) unless I18n.backend.initialized?
+    I18n.backend.send(:translations).each_with_object({}) do |(locale, tree), out|
+      collected = {}
+      walk(tree, [], partner_id, reference.to_sym, collected)
+      out[locale] = collected
+    end
+  rescue StandardError => e
+    Rails.logger.warn("DevPartnerTranslations: could not copy reference translations: #{e.message}")
+    {}
+  end
+
+  def walk(node, path, partner_id, ref, out)
+    return unless node.is_a?(Hash)
+
+    node.each do |key, value|
+      if key == ref
+        if value.is_a?(Hash)
+          # subtree pattern: re-key sandbox.* leaves as <partner_id>.*
+          leaves(value, []) { |sub, leaf| out[(path + [ partner_id ] + sub).join(".")] = leaf }
+        elsif value.is_a?(String)
+          # suffix pattern: store under the base key (db_translation strips the id)
+          out[path.join(".")] = value
+        end
+      elsif value.is_a?(Hash)
+        walk(value, path + [ key.to_s ], partner_id, ref, out)
+      end
+    end
+  end
+
+  def leaves(node, path, &blk)
+    node.each do |k, v|
+      v.is_a?(Hash) ? leaves(v, path + [ k.to_s ], &blk) : (blk.call(path + [ k.to_s ], v) if v.is_a?(String))
+    end
+  end
+end
+
+namespace :dev do
+  namespace :partner do
+    REQUIRED_PARTNER_TRANSLATIONS = ClientAgencyConfig::REQUIRED_TRANSLATION_KEYS
+    # Prefix every generated string so faked text is obvious on screen.
+    GENERATED_PREFIX = "DEV - "
+
+    desc "Generate a new partner (with translations) populated with fake data"
+    task :create, [ :partner_id ] => :environment do |_t, args|
+      abort "Refusing to run in production." if Rails.env.production?
+      require "faker"
+
+      partner_id = (args[:partner_id].presence || "dev_#{Faker::Color.color_name}_#{SecureRandom.hex(2)}")
+        .downcase.gsub(/[^a-z0-9_]/, "_")
+
+      if PartnerConfig.exists?(partner_id: partner_id)
+        abort "Partner '#{partner_id}' already exists. Pass a different id or destroy it first."
+      end
+
+      # Use an obviously-fictional "place" so a generated partner can't be mistaken
+      # for a real agency (e.g. "Naboo Department of Health", not "Iowa ...").
+      realm = Faker::Movies::StarWars.planet
+      agency_kind = [ "Department of Human Services", "Department of Economic Security",
+                      "Department of Health", "Family Assistance Administration" ].sample
+      full_name = "#{realm} #{agency_kind}"
+      acronym = full_name.scan(/\b[A-Z]/).join.presence || Faker::Alphanumeric.alpha(number: 3).upcase
+
+      result = ActiveRecord::Base.transaction do
+        config = PartnerConfig.create!(
+          partner_id: partner_id,
+          name: "#{GENERATED_PREFIX}#{full_name}",
+          state_name: realm,
+          timezone: %w[America/New_York America/Chicago America/Denver America/Los_Angeles America/Phoenix].sample,
+          website: "https://#{partner_id.tr('_', '-')}.example.gov",
+          domain: partner_id.tr("_", "-"),
+          argyle_environment: "sandbox",
+          partner_identifier_name: "case_number",
+          pay_income_days_w2: 90,
+          pay_income_days_gig: 90,
+          invitation_valid_days_default: 14,
+          # Active + enabled in every environment so it shows up wherever you look.
+          active_demo: true,
+          active_prod: true,
+          staff_portal_enabled: true,
+          generic_links_enabled: true,
+          invitation_links_enabled: true
+        )
+
+        config.partner_transmission_methods.create!(method_type: :shared_email)
+
+        [
+          { name: "case_number", required: true, show_on_caseworker_report: true },
+          { name: "first_name", required: false },
+          { name: "last_name", required: false }
+        ].each do |attrs|
+          config.partner_application_attributes.create!(
+            name: attrs[:name],
+            description: attrs[:name].humanize,
+            data_type: :string,
+            required: attrs.fetch(:required, false),
+            show_on_caseworker_report: attrs.fetch(:show_on_caseworker_report, false)
+          )
+        end
+
+        # Brand the identity strings so the partner is visibly distinct...
+        branded = {
+          "shared.agency_acronym" => acronym,
+          "shared.agency_full_name" => full_name,
+          "shared.agency_portal_name" => "#{full_name} Portal",
+          "shared.header.cbv_flow_title" => "#{acronym} Income Verification",
+          "shared.header.preheader" => Faker::Company.catch_phrase,
+          "cbv.entries.show.checkbox" => "I agree to share my income with #{acronym} (#{Faker::Company.catch_phrase})"
+        }
+        # ...and copy everything else from the reference agency so it renders
+        # everywhere without tripping the "Missing agency translation" guard.
+        # Every value is prefixed so any text on screen is identifiably generated.
+        copied = DevPartnerTranslations.for_partner(partner_id, reference: "sandbox")
+        I18n.available_locales.each do |locale|
+          (copied[locale] || {}).merge(branded).each do |key, value|
+            next unless value.is_a?(String) && value.present?
+            config.partner_translations.create!(locale: locale.to_s, key: key, value: "#{GENERATED_PREFIX}#{value}")
+          end
+        end
+
+        # Service account user + API token — the "user token" you normally POST
+        # with in Bruno against /api/v1/invitations.
+        user = User.create!(
+          client_agency_id: partner_id,
+          email: "#{partner_id}-svc@example.gov",
+          is_service_account: true
+        )
+        api_token = user.api_access_tokens.create!.access_token
+
+        # Create an invitation directly (same outcome as POST /api/v1/invitations),
+        # without sending email or emitting tracking events.
+        case_number = Faker::Number.number(digits: 8).to_s
+        invitation = CbvFlowInvitation.create!(
+          client_agency_id: partner_id,
+          user: user,
+          language: "en",
+          email_address: user.email,
+          cbv_applicant_attributes: {
+            client_agency_id: partner_id,
+            partner_identifier: case_number,
+            custom_attributes: { "first_name" => Faker::Name.first_name, "last_name" => Faker::Name.last_name }
+          }
+        )
+
+        [ config, api_token, invitation ]
+      end
+
+      partner, api_token, invitation = result
+
+      # The running dev server doesn't need this (it reloads configs lazily); it
+      # only refreshes the singleton within *this* rake process.
+      ClientAgencyConfig.reset!
+
+      sub = "http://#{partner.domain}.#{ENV.fetch('DOMAIN_NAME', 'localhost')}:3000"
+      puts <<~SUMMARY
+
+        Created partner '#{partner.partner_id}' — #{partner.name} (#{acronym})
+          subdomain:    #{partner.domain}
+          attributes:   #{partner.partner_application_attributes.pluck(:name).join(', ')}
+          translations: #{partner.partner_translations.count} rows across #{I18n.available_locales.join(', ')}
+
+        Visit it now (no reboot needed). Served on the partner subdomain, exactly
+        like the seeded partners — DOMAIN_NAME=localhost and browsers resolve
+        *.localhost to 127.0.0.1, so no /etc/hosts entry is needed:
+          landing page:      #{sub}/
+          caseworker portal: #{sub}/#{partner.partner_id}
+          generic link:      #{sub}/cbv/links/#{partner.partner_id}
+          tokenized flow:    #{sub}/start/#{invitation.auth_token}
+
+        API access (same as POSTing to /api/v1/invitations in Bruno):
+          token: #{api_token}
+          curl -X POST #{sub}/api/v1/invitations \\
+            -H "Authorization: Bearer #{api_token}" \\
+            -H "Content-Type: application/json" \\
+            -d '{"language":"en","custom_attributes":{"case_number":"12345678"}}'
+
+        Remove it with:
+          bundle exec rake "dev:partner:destroy[#{partner.partner_id}]"
+      SUMMARY
+    end
+
+    desc "Destroy a partner created for dev validation"
+    task :destroy, [ :partner_id ] => :environment do |_t, args|
+      abort "Refusing to run in production." if Rails.env.production?
+      partner_id = args[:partner_id].presence or abort "Usage: rake \"dev:partner:destroy[partner_id]\""
+
+      config = PartnerConfig.find_by(partner_id: partner_id) or abort "Partner '#{partner_id}' not found."
+
+      # Delete children explicitly: PartnerConfig#destroy is unusable here because
+      # its `has_many :partner_transmission_configs, dependent: :destroy` points at
+      # a column (partner_config_id) that doesn't exist on that table — those
+      # configs hang off partner_transmission_methods instead.
+      ActiveRecord::Base.transaction do
+        # Flow data created by actually using the partner, deleted leaf-first to
+        # satisfy FK constraints (webhook_events -> payroll_accounts -> cbv_flows;
+        # cbv_flows -> cbv_flow_invitations). delete_all is used because the AR
+        # cascade is incomplete (PayrollAccount has_many :webhook_events has no
+        # dependent: :destroy).
+        flow_ids = CbvFlow.where(client_agency_id: partner_id).pluck(:id)
+        payroll_account_ids = PayrollAccount.where(cbv_flow_id: flow_ids).pluck(:id)
+        WebhookEvent.where(payroll_account_id: payroll_account_ids).delete_all
+        PayrollAccount.where(id: payroll_account_ids).delete_all
+        CbvFlowTransmission.where(cbv_flow_id: flow_ids).delete_all
+        CbvFlow.where(id: flow_ids).delete_all
+        CbvFlowInvitation.where(client_agency_id: partner_id).delete_all
+        CbvApplicant.where(client_agency_id: partner_id).delete_all
+
+        user_ids = User.where(client_agency_id: partner_id).pluck(:id)
+        ApiAccessToken.where(user_id: user_ids).delete_all
+        User.where(id: user_ids).delete_all
+
+        # Partner config + children (see note above re: PartnerConfig#destroy).
+        method_ids = config.partner_transmission_methods.pluck(:id)
+        PartnerTransmissionConfig.where(partner_transmission_method_id: method_ids).delete_all
+        config.partner_transmission_methods.delete_all
+        config.partner_application_attributes.delete_all
+        config.partner_translations.delete_all
+        config.delete
+      end
+
+      ClientAgencyConfig.reset!
+      puts "Destroyed partner '#{partner_id}'."
+    end
+
+    desc "List configured partners"
+    task list: :environment do
+      printf("%-24s %-40s %s\n", "partner_id", "name", "domain")
+      PartnerConfig.order(:partner_id).each do |c|
+        printf("%-24s %-40s %s\n", c.partner_id, c.name, c.domain)
+      end
+    end
+  end
+end

--- a/app/lib/tasks/dev_partner.rake
+++ b/app/lib/tasks/dev_partner.rake
@@ -60,10 +60,11 @@ namespace :dev do
     REQUIRED_PARTNER_TRANSLATIONS = ClientAgencyConfig::REQUIRED_TRANSLATION_KEYS
     # Prefix every generated string so faked text is obvious on screen.
     GENERATED_PREFIX = "DEV - "
+    NON_PRODUCTION = Object.new.extend(NonProductionAccessible)
 
     desc "Generate a new partner (with translations) populated with fake data"
     task :create, [ :partner_id ] => :environment do |_t, args|
-      abort "Refusing to run in production." if Rails.env.production?
+      abort "Refusing to run in production." unless NON_PRODUCTION.is_not_production?
       require "faker"
 
       partner_id = (args[:partner_id].presence || "dev_#{Faker::Color.color_name}_#{SecureRandom.hex(2)}")
@@ -201,7 +202,7 @@ namespace :dev do
 
     desc "Destroy a partner created for dev validation"
     task :destroy, [ :partner_id ] => :environment do |_t, args|
-      abort "Refusing to run in production." if Rails.env.production?
+      abort "Refusing to run in production." unless NON_PRODUCTION.is_not_production?
       partner_id = args[:partner_id].presence or abort "Usage: rake \"dev:partner:destroy[partner_id]\""
 
       config = PartnerConfig.find_by(partner_id: partner_id) or abort "Partner '#{partner_id}' not found."

--- a/app/spec/controllers/caseworker/cbv_flow_invitations_controller/auth_spec.rb
+++ b/app/spec/controllers/caseworker/cbv_flow_invitations_controller/auth_spec.rb
@@ -17,11 +17,10 @@ RSpec.describe Caseworker::CbvFlowInvitationsController, type: :controller do
     end
 
     context "with an invalid client agency id" do
-      it "raises a routing error" do
+      it "raises a routing error (unknown partner has no route)" do
         expect {
           get :new, params: valid_params.tap { |p| p[:client_agency_id] = "this-is-not-a-site-id" }
-        }.to raise_error(ActionController::UrlGenerationError)
-        expect response.status == 404
+        }.to raise_error(ActionController::RoutingError)
       end
     end
 

--- a/app/spec/helpers/application_helper_spec.rb
+++ b/app/spec/helpers/application_helper_spec.rb
@@ -216,6 +216,30 @@ RSpec.describe ApplicationHelper do
     end
   end
 
+  describe "#agency_translation with a relative (leading-dot) key" do
+    let(:current_agency) { ClientAgencyConfig.instance["sandbox"] }
+
+    before do
+      without_partial_double_verification do
+        allow(helper).to receive(:current_agency).and_return(current_agency)
+      end
+      # Set by ActionView during template rendering; scopes leading-dot keys.
+      helper.instance_variable_set(:@virtual_path, "cbv/entries/show")
+    end
+
+    it "expands the relative key so a full-key DB translation is used" do
+      partner = PartnerConfig.find_by(partner_id: "sandbox")
+      PartnerTranslation.create!(
+        partner_config: partner,
+        locale: "en",
+        key: "cbv.entries.show.checkbox",
+        value: "DB checkbox label"
+      )
+
+      expect(helper.agency_translation(".checkbox")).to eq("DB checkbox label")
+    end
+  end
+
   describe "#feedback_form_url" do
     let(:current_agency) { nil }
     let(:params) { {} }

--- a/app/spec/lib/client_agency_config_spec.rb
+++ b/app/spec/lib/client_agency_config_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe ClientAgencyConfig do
     end
   end
 
+  before do
+    # Avoid reporting validation warnings to New Relic during these specs.
+    allow(NewRelic::Agent).to receive(:notice_error) if defined?(NewRelic::Agent)
+  end
+
   let!(:sample_config) do
     pc = PartnerConfig.create!(
       partner_id: 'foo',
@@ -73,18 +78,121 @@ RSpec.describe ClientAgencyConfig do
     context "when path_prefix starts with /" do
       let(:bad_prefix) { "/inbox" }
 
-      it "raises an ArgumentError at agency load" do
-        expect { ClientAgencyConfig.new(true) }
-          .to raise_error(ArgumentError, %r{Client Agency bad_s3.*must not start with '/'})
+      it "is unavailable and logs an error instead of raising when requested" do
+        allow(Rails.logger).to receive(:error)
+        config = ClientAgencyConfig.new(true)
+
+        result = nil
+        expect { result = config["bad_s3"] }.not_to raise_error
+        expect(result).to be_nil
+        expect(Rails.logger).to have_received(:error)
+          .with(%r{bad_s3 failed validation.*must not start with '/'}).at_least(:once)
+      end
+
+      it "logs the failure during the boot validation pass without raising" do
+        allow(Rails.logger).to receive(:error)
+
+        expect { ClientAgencyConfig.new(true).validate_all }.not_to raise_error
+        expect(Rails.logger).to have_received(:error)
+          .with(%r{bad_s3 failed validation.*must not start with '/'})
       end
     end
 
     context "when path_prefix is a relative path" do
       let(:bad_prefix) { "inbox/prod" }
 
-      it "loads without raising" do
-        expect { ClientAgencyConfig.new(true) }.not_to raise_error
+      it "loads the agency without raising" do
+        config = ClientAgencyConfig.new(true)
+        expect(config["bad_s3"]).to be_present
       end
+    end
+  end
+
+  describe "lazy loading" do
+    it "does not construct any agency when the instance is created" do
+      expect(ClientAgencyConfig::ClientAgency).not_to receive(:new)
+      ClientAgencyConfig.new(true)
+    end
+
+    it "loads an agency from the database on first access and memoizes it" do
+      config = ClientAgencyConfig.new(true)
+
+      expect(PartnerConfig).to receive(:find_by).with(partner_id: "foo").once.and_call_original
+
+      2.times { expect(config["foo"].agency_name).to eq("Foo Agency Name") }
+    end
+
+    it "returns nil for an unknown agency and does not cache the miss" do
+      config = ClientAgencyConfig.new(true)
+
+      expect(PartnerConfig).to receive(:find_by).with(partner_id: "ghost").exactly(2).times.and_call_original
+
+      expect(config["ghost"]).to be_nil
+      expect(config["ghost"]).to be_nil
+    end
+
+    it "returns nil for a blank id without touching the database" do
+      config = ClientAgencyConfig.new(true)
+
+      expect(PartnerConfig).not_to receive(:find_by)
+
+      expect(config[nil]).to be_nil
+      expect(config[""]).to be_nil
+    end
+
+    it "serves a cached agency without re-querying while the entry is fresh" do
+      config = ClientAgencyConfig.new(true)
+      fake_time = 0.0
+      allow(config).to receive(:now) { fake_time }
+
+      expect(PartnerConfig).to receive(:find_by).with(partner_id: "foo").once.and_call_original
+
+      config["foo"]
+      fake_time = ClientAgencyConfig::CACHE_TTL_SECONDS - 1
+      config["foo"]
+    end
+
+    it "reloads on every lookup in development so config edits are immediate" do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
+      config = ClientAgencyConfig.new(true)
+
+      expect(PartnerConfig).to receive(:find_by).with(partner_id: "foo").twice.and_call_original
+
+      config["foo"]
+      config["foo"]
+    end
+
+    it "picks up database changes after the cache TTL expires" do
+      config = ClientAgencyConfig.new(true)
+      fake_time = 0.0
+      allow(config).to receive(:now) { fake_time }
+
+      expect(config["foo"].agency_name).to eq("Foo Agency Name")
+
+      sample_config.update!(name: "Renamed Foo Agency")
+
+      # Still within the TTL: the cached value is returned.
+      fake_time = ClientAgencyConfig::CACHE_TTL_SECONDS - 1
+      expect(config["foo"].agency_name).to eq("Foo Agency Name")
+
+      # Past the TTL: the agency is reloaded from the database.
+      fake_time = ClientAgencyConfig::CACHE_TTL_SECONDS + 1
+      expect(config["foo"].agency_name).to eq("Renamed Foo Agency")
+    end
+  end
+
+  describe "#find_by_domain" do
+    it "resolves an agency by its configured domain" do
+      config = ClientAgencyConfig.new(true)
+      agency = config.find_by_domain("sandbox")
+
+      expect(agency).to be_present
+      expect(agency.id).to eq("sandbox")
+    end
+
+    it "returns nil for an unrecognized domain" do
+      config = ClientAgencyConfig.new(true)
+      expect(config.find_by_domain("not-a-domain")).to be_nil
     end
   end
 
@@ -102,6 +210,39 @@ RSpec.describe ClientAgencyConfig do
       agency = config["foo"]
 
       expect(agency.require_applicant_information_on_invitation).to eq(true)
+    end
+  end
+
+  describe "#validate_all" do
+    let!(:partner_without_attributes) do
+      pc = PartnerConfig.create!(
+        partner_id: 'no_attrs',
+        name: 'No Attributes Agency',
+        timezone: 'America/Los_Angeles',
+        argyle_environment: 'sandbox',
+        pay_income_days_w2: 90,
+        pay_income_days_gig: 90,
+        partner_identifier_name: 'first_name'
+      )
+      pc.partner_transmission_methods.create!(method_type: :shared_email)
+      pc
+    end
+
+    it "logs an error for a partner missing application attributes without raising" do
+      allow(Rails.logger).to receive(:error)
+
+      expect { ClientAgencyConfig.new(true).validate_all }.not_to raise_error
+      expect(Rails.logger).to have_received(:error)
+        .with(/no_attrs has no partner_application_attributes/)
+    end
+
+    it "warns lazily on the live request that loads the misconfigured partner" do
+      allow(Rails.logger).to receive(:error)
+      config = ClientAgencyConfig.new(true)
+
+      expect(config["no_attrs"]).to be_present
+      expect(Rails.logger).to have_received(:error)
+        .with(/no_attrs has no partner_application_attributes/)
     end
   end
 end

--- a/app/spec/lib/constraints/client_agency_id_constraint_spec.rb
+++ b/app/spec/lib/constraints/client_agency_id_constraint_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+require "constraints/client_agency_id_constraint"
+
+RSpec.describe ClientAgencyIdConstraint do
+  subject(:constraint) { described_class.new }
+
+  def request_for(client_agency_id)
+    instance_double(ActionDispatch::Request, path_parameters: { client_agency_id: client_agency_id })
+  end
+
+  it "matches a known partner id (loaded dynamically from the database)" do
+    expect(constraint.matches?(request_for("sandbox"))).to be(true)
+  end
+
+  it "does not match an unknown partner id" do
+    expect(constraint.matches?(request_for("definitely-not-a-partner"))).to be(false)
+  end
+
+  it "does not match a blank id" do
+    expect(constraint.matches?(request_for(nil))).to be(false)
+  end
+end

--- a/app/spec/routing/dynamic_client_agency_routing_spec.rb
+++ b/app/spec/routing/dynamic_client_agency_routing_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+# Verifies that partner routes are resolved dynamically from the database at
+# request time rather than enumerated into the route table at boot.
+RSpec.describe "Dynamic client agency routing", type: :routing do
+  it "recognizes the caseworker route for a known partner id" do
+    expect(get: "/sandbox").to be_routable
+  end
+
+  it "does not recognize a route for an unknown partner id" do
+    expect(get: "/definitely-not-a-partner").not_to be_routable
+  end
+
+  it "recognizes the generic link route for a known partner id" do
+    expect(get: "/cbv/links/sandbox").to be_routable
+  end
+
+  # Verify that a newly-created partner is routable.
+  it "recognizes a partner created after the routes were drawn" do
+    partner = FactoryBot.create(:partner_config, partner_id: "brand_new_partner", domain: "brandnew")
+    FactoryBot.create(:partner_application_attribute, partner_config: partner)
+
+    expect(get: "/brand_new_partner").to be_routable
+  end
+end


### PR DESCRIPTION
## Summary
Implements PF-642 by making route loading dynamic. Partners are now lazy-loaded and cached to a short TTL. App restarts are no longer needed to effect partner configuration additions/removals/updates.

## Type of Change
Check all that apply.
- [ ] Bug
- [x] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
[add concise bullet points of changes here]

## Checklist
- [x] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
[if anything need special attention, note it here]


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213547878535992