### PR TITLE
Jeffcatania/fix ssn disclaimer text

### DIFF
--- a/app/app/views/cbv/payment_details/show.html.erb
+++ b/app/app/views/cbv/payment_details/show.html.erb
@@ -22,7 +22,7 @@
         </svg>
       </div>
       <div class="usa-icon-list__content">
-        <%= t(".ssn_disclaimer", agency_acronym: agency_translation("shared.agency_acronym")) %>
+        <%= t(".ssn_disclaimer", agency_acronym: agency_acronym_or_full_name) %>
       </div>
     </li>
   </ul>


### PR DESCRIPTION
Fixes bug with agency acronym fallback for SSN. 
<img width="736" height="1126" alt="image" src="https://github.com/user-attachments/assets/61628e25-b68d-48c6-bcee-f2eec4e3acca" />

Fix: 
<img width="844" height="375" alt="image" src="https://github.com/user-attachments/assets/ca2263ef-18c0-4b0b-b8ee-0d531a2eeb50" />
