### PR TITLE
fix ssn disclaimer text on income report

### DIFF
--- a/app/app/views/cbv/submits/show.pdf.erb
+++ b/app/app/views/cbv/submits/show.pdf.erb
@@ -26,7 +26,7 @@
 <% else %>
   <p><%= t(".pdf.client.description", agency_acronym: agency_acronym_or_full_name) %></p>
   <% if current_agency&.include_full_ssn %>
-    <p><%= t(".pdf.client.ssn_disclaimer", agency_acronym: agency_translation("shared.agency_acronym")) %></p>
+    <p><%= t(".pdf.client.ssn_disclaimer", agency_acronym: agency_acronym_or_full_name) %></p>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
Fixes issue with "to to" on ssn disclaimer on income report for agencies with no acronym