### PR TITLE
fix synchronizations failure page translations bug 

### DIFF
--- a/app/app/views/cbv/synchronization_failures/show.html.erb
+++ b/app/app/views/cbv/synchronization_failures/show.html.erb
@@ -22,7 +22,7 @@
     <% if @cbv_flow.has_account_with_required_data? %>
       <%= link_to t(".continue_to_report"), cbv_flow_applicant_information_path, class: "usa-button" %>
     <% else %>
-      <%= agency_translation("cbv.expired_invitations.show.cta_button_html", agency_url: agency_url) %>
+      <%= agency_translation("cbv.expired_invitations.show.cta_button_html", agency_url: agency_url, agency_portal_name: agency_translation("shared.agency_portal_name")) %>
     <% end %>
   </li>
 </ul>


### PR DESCRIPTION
Fix: missing interpolation argument :agency_portal_name not being passed into translation string required on synchronizations failures page. 
