### PR TITLE
Overriding USWDS tile checkbox background color

### DIFF
--- a/app/app/assets/stylesheets/uswds-overrides.scss
+++ b/app/app/assets/stylesheets/uswds-overrides.scss
@@ -27,6 +27,17 @@
   max-width: none;
 }
 
+// USWDS tile checkboxes fill the label with a translucent blue background
+// when checked, which drops the focus ring below the 3:1 non-text contrast
+// minimum. Keep the border as the checked-state indicator and drop the fill.
+.usa-checkbox__input--tile {
+  &:checked, {
+    + [class*="__label"] {
+      background-color: color($theme-body-background-color);
+    }
+  }
+}
+
 
 // Make the navbar a bit taller on mobile, and increase the size of the "Menu"
 // button to compensate.


### PR DESCRIPTION
  ## Notes for Reviewers

The translucent blue background is a USWDS default for checked tile checkboxes. The keyboard focus ring's contrast against that background dropped below the required 3:1 minimum.

  Type of Change

  - [x] Bug
  - [ ] Feature
  - [ ] Refactor
  - [ ] Documentation update

## Changes

  - Added an override in `app/app/assets/stylesheets/uswds-overrides.scss` that resets the checked-state background of` .usa-checkbox__input--tile` labels to `$theme-body-background-color` (resolves to white), removing the light-blue fill while keeping the existing blue border as the checked-state indicator.
  - Used the existing USWDS `$theme-body-background-color` setting (the same token USWDS's own tile-checkbox mixin uses for its default/unchecked background) so the override stays correct if the theme's body background is ever changed (dark-mode etc.)

 ## Checklist

  - [ ] Tests added/updated (if needed)
  - [ ] Docs updated (if needed)

  ## Notes for Reviewers

  - Affects both checkboxes in the app that use the --tile USWDS variant
      -  Attestation checkboxes on` /cbv/entry` and `/cbv/submit` (both rendered via UswdsFormBuilder#check_box).
  - No automated test covers this regression
      -  .pa11yci's static scan of `/cbv/entry` does not handle interactions and axe-core doesn't have an automated rule for WCAG 1.4.11 non-text contrast.
      - Verified manually instead (tab + space to check the box, confirmed background stays white).
  - The selector currently only overrides the `:checked` state. USWDS applies the same translucent-blue fill to `:indeterminate/[data-indeterminate]` tile checkboxes too, but neither of this app's two checkboxes is ever set indeterminate and it's enough of an edge case that I decided against adding additional complexity to the SCSS. 
 - Worth knowing in case a future tile checkbox elsewhere in the app needs the same treatment.

<img width="721" height="473" alt="Screenshot 2026-07-02 130759" src="https://github.com/user-attachments/assets/d35d707a-f8ec-4fd4-abea-53666b981b52" />
<img width="685" height="613" alt="Screenshot 2026-07-02 131506" src="https://github.com/user-attachments/assets/5e2663cc-5712-44d5-9c1e-90da19dd8e03" />


## Outstanding Questions
 - Is there a preference to inherit the background color from the parent or make the background translucent instead of explicitly setting a themed color? My thought was that I would prefer to stick to themed color schemes because it would make it more clear what was happening in the code. But just wanted to see if there were any strong feelings about this. 