### PR TITLE
Associating employer search label with text field

### DIFF
--- a/app/app/views/cbv/employer_searches/show.html.erb
+++ b/app/app/views/cbv/employer_searches/show.html.erb
@@ -11,7 +11,7 @@
     <%= t(".header") %>
   </h1>
   <div class="display-flex flex-align-center text-ink font-sans-md">
-    <span><%= t(".company_name") %></span>
+    <%= label_tag :query, t(".company_name") %>
     <button type="button"
             class="usa-button usa-button--unstyled text-ink usa-tooltip margin-left-05"
             data-position="right"
@@ -25,11 +25,10 @@
     </button>
   </div>
 
-  <div class="text-gray-50"><%= t(".company_examples") %></div>
+  <div id="company_examples" class="text-gray-50"><%= t(".company_examples") %></div>
 
   <%= form_with url: cbv_flow_employer_search_path, method: :get, class: "usa-search usa-search--big margin-bottom-4 margin-top-2", html: { role: "search" }, data: { turbo_frame: "employers", turbo_action: "advance" } do |f| %>
-    <%= f.label :query, "Search for your employer", class: "usa-sr-only" %>
-    <%= f.text_field :query, value: @query, class: "usa-input", type: "search" %>
+    <%= f.text_field :query, value: @query, class: "usa-input", type: "search", aria: { describedby: "company_examples" } %>
     <button
       class="usa-button"
       type="submit">


### PR DESCRIPTION
## Summary
There was a visible label and a screen-reader only label that were mismatched.

## Type of Change
Check all that apply.
- [x] Bug
- [ ] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
- File touched: `app/app/views/cbv/employer_searches/show.html.erb`.
- Replaced the plain `<span>` wrapping "Company Name" with a real `<%= label_tag :query, t(".company_name") %>`, so the field's accessible name now matches its visible label exactly ("Company Name") instead of the mismatched hidden string "Search for your employer".
- Removed the now-redundant hidden `f.label :query, "Search for your employer", class: "usa-sr-only"`
### Additional work:
- Added `id="company_examples"` to the "Examples: Uber, McDonald's, ADP" div and `aria-describedby="company_examples"` on the search input, so screen readers announce the examples as a description of the field.


## Checklist
- [ ] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
- The fix reuses the existing `company_name` translation, so both English and Spanish locales stay in sync automatically and we are not maintaining two sets of labels
- The resulting accessible name is "Company Name" only; it does **not** append the word "Search" from the submit button, which the original ticket's example string ("Search by Employer/Company Name") would have included. The text field is correctly typed as "search" so this should be sufficient. This was a deliberate call to keep the visible label and accessible name identical rather than inventing new label text — flagging in case the AC wording needs reconciling.

### Before
<img width="828" height="265" alt="Screenshot 2026-07-06 144053" src="https://github.com/user-attachments/assets/10340f95-001c-491f-9118-3534e06059fd" />

### After 
<img width="858" height="280" alt="Screenshot 2026-07-06 135948" src="https://github.com/user-attachments/assets/f658378d-d65e-4eab-9bd0-0bf773d75c54" />
