### PR TITLE
Adding employer name as sr-only text to search select button

### DIFF
--- a/app/app/views/cbv/employer_searches/_employer.html.erb
+++ b/app/app/views/cbv/employer_searches/_employer.html.erb
@@ -36,10 +36,9 @@
               data-provider-name="<%= employer.provider_name %>"
               class="usa-button usa-button--outline"
               type="button"
-              tabindex="0"
-              aria-label="<%= employer.name %>"
             >
               <%= t("cbv.employer_searches.show.select") %>
+              <span class="usa-sr-only"><%= employer.name %></span>
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
The employer search select buttons had an explicit aria-label with just the employer name. Aria labels are considered the highest level of importance and were overwriting the button text. Removed the aria-label and added sr-only text to include company name in button text

## Type of Change
Check all that apply.
- [x] Bug
- [ ] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
- Removed aria-label
- Included sr-only text inside button with `<%= employer.name %>`

### Additional work
- Removed tab-index from the button, by default a button will have a `tabindex=0` and there is no need to explicitly set this. 

## Checklist
- [ ] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
N/A
