### PR TITLE
Ordering Headings to maintian Review Payment page hierarchy

### DIFF
--- a/app/app/components/report/gig_monthly_summary_table_component.html.erb
+++ b/app/app/components/report/gig_monthly_summary_table_component.html.erb
@@ -2,9 +2,9 @@
 
 <% if show_table %>
   <div class="margin-top-5">
-    <h2 class="margin-0">
+    <h3 class="margin-0">
       <%= I18n.t("components.report.monthly_summary_table.monthly_summary") %> <% if @is_pdf %><span class="yellow-highlight-label font-size-pdf-header-tag"><%= t("cbv.submits.show.pdf.client.self_employment") %></span><% end %>
-    </h2>
+    </h3>
     <%= render(TableComponent.new(is_responsive: @is_responsive)) do |table| %>
       <%= table.with_subheader_row(class_names: "subheader-row base-lightest") do |row| %>
         <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")

--- a/app/app/components/report/w2_monthly_summary_table_component.html.erb
+++ b/app/app/components/report/w2_monthly_summary_table_component.html.erb
@@ -1,7 +1,7 @@
 <div class="margin-top-5">
-  <h2 class="margin-0">
+  <h3 class="margin-0">
     <%= I18n.t("components.report.monthly_summary_table.monthly_summary") %>
-  </h2>
+  </h3>
   <%= render(TableComponent.new(is_responsive: @is_responsive)) do |table| %>
     <%= table.with_subheader_row(class_names: "subheader-row base-lightest") do |row| %>
       <%= row.with_data_cell(is_header: true, class_names: "text-nowrap")

--- a/app/app/components/report/w2_paystub_details_table_component.html.erb
+++ b/app/app/components/report/w2_paystub_details_table_component.html.erb
@@ -38,7 +38,7 @@
 <% end %>
 <% if show_earnings_items? %>
   <aside class="paystub_earnings_items bg-base-lightest padding-x-4 padding-y-3 margin-bottom-8">
-  <h4><%= t("components.report.w2_paystub_details_table.earnings_items_title") %></h4>
+  <h5><%= t("components.report.w2_paystub_details_table.earnings_items_title") %></h5>
   <p><%= t("components.report.w2_paystub_details_table.earnings_items_description") %></p>
   <%= render(TableComponent.new(is_responsive: @is_responsive, thead_class_names: "", class_names: "paystub_earnings_items_table margin-bottom-0")) do |table| %>
     <% earnings_sort_order(@paystub.earnings.filter { |earning| earning.amount.to_f > 0 }).each do |earning| %>

--- a/app/spec/components/report/gig_monthly_summary_table_component_spec.rb
+++ b/app/spec/components/report/gig_monthly_summary_table_component_spec.rb
@@ -135,10 +135,6 @@ RSpec.describe Report::GigMonthlySummaryTableComponent, type: :component do
         expect(subject.css("thead tr.subheader-row th").length).to eq(4)
       end
 
-      it "renders the monthly summary heading as an h3, not an h2" do
-        expect(subject.css("h2").text).not_to include "Monthly summary"
-      end
-
       it "renders the Month column with the correct date format" do
         expect(subject.css("thead tr.subheader-row th:nth-child(1)").to_html).to include "Month"
         expect(subject.css("tbody tr:nth-child(1) th:nth-child(1)").to_html).to include "March 2025"
@@ -303,10 +299,6 @@ RSpec.describe Report::GigMonthlySummaryTableComponent, type: :component do
       it "includes table header" do
         expect(subject.css("h3").to_html).to include "Monthly summary"
         expect(subject.css("thead tr.subheader-row th").length).to eq(4)
-      end
-
-      it "renders the monthly summary heading as an h3, not an h2" do
-        expect(subject.css("h2").text).not_to include "Monthly summary"
       end
 
       it "renders the Month column with the correct date format" do

--- a/app/spec/components/report/gig_monthly_summary_table_component_spec.rb
+++ b/app/spec/components/report/gig_monthly_summary_table_component_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Report::GigMonthlySummaryTableComponent, type: :component do
       end
 
       it "includes table header" do
-        expect(subject.css("h2").to_html).to include "Monthly summary"
+        expect(subject.css("h3").to_html).to include "Monthly summary"
         expect(subject.css("thead tr.subheader-row th").length).to eq(3)
       end
 
@@ -131,8 +131,12 @@ RSpec.describe Report::GigMonthlySummaryTableComponent, type: :component do
       end
 
       it "includes table header" do
-        expect(subject.css("h2").to_html).to include "Monthly summary"
+        expect(subject.css("h3").to_html).to include "Monthly summary"
         expect(subject.css("thead tr.subheader-row th").length).to eq(4)
+      end
+
+      it "renders the monthly summary heading as an h3, not an h2" do
+        expect(subject.css("h2").text).not_to include "Monthly summary"
       end
 
       it "renders the Month column with the correct date format" do
@@ -264,7 +268,7 @@ RSpec.describe Report::GigMonthlySummaryTableComponent, type: :component do
       end
 
       it "does not render table when no data found" do
-        expect(subject.css("h2").to_html).not_to include "Monthly summary"
+        expect(subject.css("h3").to_html).not_to include "Monthly summary"
         expect(subject.css("thead tr.subheader-row th").length).to eq(0)
       end
 
@@ -297,8 +301,12 @@ RSpec.describe Report::GigMonthlySummaryTableComponent, type: :component do
       end
 
       it "includes table header" do
-        expect(subject.css("h2").to_html).to include "Monthly summary"
+        expect(subject.css("h3").to_html).to include "Monthly summary"
         expect(subject.css("thead tr.subheader-row th").length).to eq(4)
+      end
+
+      it "renders the monthly summary heading as an h3, not an h2" do
+        expect(subject.css("h2").text).not_to include "Monthly summary"
       end
 
       it "renders the Month column with the correct date format" do
@@ -353,7 +361,7 @@ RSpec.describe Report::GigMonthlySummaryTableComponent, type: :component do
       end
 
       it "includes table header" do
-        expect(subject.css("h2").to_html).to include "Monthly summary"
+        expect(subject.css("h3").to_html).to include "Monthly summary"
         expect(subject.css("thead tr.subheader-row th").length).to eq(3)
       end
 
@@ -405,7 +413,7 @@ RSpec.describe Report::GigMonthlySummaryTableComponent, type: :component do
   subject { render_inline(described_class.new(argyle_report, payroll_account)) }
 
   it "shows hours in monthly summary but no payment accordion" do
-    expect(subject.css('h2').text).to include("Monthly summary")
+    expect(subject.css('h3').text).to include("Monthly summary")
     expect(subject.css('tbody tr').length).to be > 0
 
     expect(subject.css('button.usa-accordion__button')).to be_empty
@@ -436,7 +444,7 @@ end
       end
 
       it "includes table header with mileage column" do
-        expect(subject.css("h2").to_html).to include "Monthly summary"
+        expect(subject.css("h3").to_html).to include "Monthly summary"
         expect(subject.css("thead tr.subheader-row th").length).to eq(4)
         expect(subject.css("thead tr.subheader-row th:nth-child(3)").to_html).to include "Verified mileage expenses"
       end

--- a/app/spec/components/report/w2_monthly_summary_table_component_spec.rb
+++ b/app/spec/components/report/w2_monthly_summary_table_component_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Report::W2MonthlySummaryTableComponent, type: :component do
       end
 
       it "includes table header" do
-        expect(subject.css("h2").to_html).to include "Monthly summary"
+        expect(subject.css("h3").to_html).to include "Monthly summary"
         expect(subject.css("thead tr.subheader-row th").length).to eq(4)
       end
 
@@ -195,7 +195,7 @@ RSpec.describe Report::W2MonthlySummaryTableComponent, type: :component do
       end
 
       it "includes table header" do
-        expect(subject.css("h2").to_html).to include "Monthly summary"
+        expect(subject.css("h3").to_html).to include "Monthly summary"
         expect(subject.css("thead tr.subheader-row th").length).to eq(4)
       end
 


### PR DESCRIPTION
## Summary
Ensuring that headings are ordered in a logical manner. 

## Type of Change
Check all that apply.
- [x] Bug
- [ ] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
- Demote `Gross pay line Items` to an` h5`, under `Payment details: (Pay Date)`  as an `h4`
- Demote `Monthly Summary` to an `h3`, under `Employment Information` as an `h2`
    - Changes required for both `gig_monthly_summary_table_component` and `w2_monthly_summary_table_component`

## Checklist
- [x] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers

### GROSS PAY LINE ITEM
<img width="1019" height="366" alt="Screenshot 2026-07-07 151048" src="https://github.com/user-attachments/assets/a3233130-4e9e-431c-9534-8be48db344ad" />

### MONTHLY (w2)
<img width="733" height="285" alt="Screenshot 2026-07-07 151312" src="https://github.com/user-attachments/assets/a262af88-a87c-429f-80f3-2094557a9b7a" />

### MONTHLY (gig)
<img width="643" height="739" alt="Screenshot 2026-07-07 151352" src="https://github.com/user-attachments/assets/71f8448f-ab69-4da9-af38-070b40f3dfe5" />
