### PR TITLE
PF-636: Enable Argyle Spanish support when the user is using a Spanish locale.

### DIFF
--- a/app/app/javascript/adapters/ArgyleModalAdapter.ts
+++ b/app/app/javascript/adapters/ArgyleModalAdapter.ts
@@ -28,6 +28,7 @@ export default class ArgyleModalAdapter extends ModalAdapter {
           userToken: user.user_token,
           flowId: flowId,
           items: [this.requestData.id],
+          language: locale,
           onAccountConnected: this.onSuccess.bind(this),
           onTokenExpired: this.onTokenExpired.bind(this),
           onAccountCreated: async (payload) => {

--- a/app/app/javascript/types/Argyle.d.ts
+++ b/app/app/javascript/types/Argyle.d.ts
@@ -19,6 +19,7 @@ type ArgyleInitializationParams = {
   onError?: (payload: LinkError) => void
   onUIEvent?: (payload: ArgyleUIEvent) => void
   sandbox?: boolean
+  language?: string
 }
 
 type Argyle = {

--- a/app/spec/javascript/adapters/ArgyleModalAdapter.spec.js
+++ b/app/spec/javascript/adapters/ArgyleModalAdapter.spec.js
@@ -84,6 +84,31 @@ describe("ArgyleModalAdapter", () => {
       )
       expect(mockArgyleAuthToken.isSandbox).toBe(true)
     })
+    it("passes the current document locale as the language param", async () => {
+      expect(Argyle.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          language: "en",
+        })
+      )
+    })
+    it("passes 'es' as the language param when the document locale is Spanish", async () => {
+      const previousLang = document.documentElement.lang
+      document.documentElement.lang = "es"
+      try {
+        Argyle.create.mockClear()
+        const esAdapter = new ArgyleModalAdapter(Argyle)
+        esAdapter.init(modalAdapterArgs)
+        await esAdapter.open()
+        expect(Argyle.create).toHaveBeenCalledTimes(1)
+        expect(Argyle.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            language: "es",
+          })
+        )
+      } finally {
+        document.documentElement.lang = previousLang
+      }
+    })
   })
 
   describe("event:onSuccess", () => {


### PR DESCRIPTION
## Summary
Implements PF-636: Enable Argyle Spanish support when the user is using a Spanish locale.

## Type of Change
Check all that apply.
- [ ] Bug
- [x] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
[add concise bullet points of changes here]

## Checklist
- [x] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
[if anything need special attention, note it here]


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213533642192920