### PR TITLE
Alt text for logos: Header & Company Select

### DIFF
--- a/app/app/helpers/application_helper.rb
+++ b/app/app/helpers/application_helper.rb
@@ -100,6 +100,11 @@ module ApplicationHelper
     "#{full_name} (#{agency_translation("shared.agency_acronym")})"
   end
 
+  # Alt text for the agency logo image (e.g. "DHS Logo").
+  def agency_logo_alt_text
+    "#{agency_acronym_or_full_name} Logo"
+  end
+
   # A reusable anchor tag to the agency portal
   def agency_website_link(label: agency_website_link_label)
     url = current_agency&.agency_contact_website

--- a/app/app/views/application/_header.html.erb
+++ b/app/app/views/application/_header.html.erb
@@ -27,8 +27,7 @@
             "display-none tablet:display-flex" : "display-flex" %> flex-align-center">
             <% if logo_path %>
               <%= image_tag logo_path, class: "cbv-header__agency-logo cbv-header__agency-logo--#{current_agency.id}",
-                            alt: "#{agency_acronym_or_full_name} Logo",
-                            title: "#{agency_acronym_or_full_name} Logo" %>
+                            alt: agency_logo_alt_text %>
             <% end %>
 
             <% if show_agency_text %>
@@ -37,7 +36,8 @@
           </div>
 
           <% if has_logo %>
-            <%= image_tag current_agency.logo_path, class: "cbv-header__agency-logo cbv-header__agency-logo--#{current_agency.id} tablet:display-none" %>
+            <%= image_tag current_agency.logo_path, class: "cbv-header__agency-logo cbv-header__agency-logo--#{current_agency.id} tablet:display-none",
+                          alt: agency_logo_alt_text %>
           <% end %>
         </em>
       </div>

--- a/app/app/views/cbv/employer_searches/_employer.html.erb
+++ b/app/app/views/cbv/employer_searches/_employer.html.erb
@@ -18,9 +18,10 @@
           <% if employer.logo_url.present? %>
             <div class="usa-card__media usa-card__media--inset display-flex flex-justify-center">
               <div class="usa-card__img cbv-employer-card__img">
+                <%# alt is intentionally blank to mark this as a decorative image %>
                 <img
                   src="<%= employer.logo_url.sub(/^http:/, "https:") %>"
-                  alt="" # NOTE: Intentionally left blank to mark as decorative image
+                  alt=""
                 >
               </div>
             </div>

--- a/app/app/views/cbv/employer_searches/_employer.html.erb
+++ b/app/app/views/cbv/employer_searches/_employer.html.erb
@@ -20,7 +20,7 @@
               <div class="usa-card__img cbv-employer-card__img">
                 <img
                   src="<%= employer.logo_url.sub(/^http:/, "https:") %>"
-                  alt="A placeholder image"
+                  alt="" # NOTE: Intentionally left blank to mark as decorative image
                 >
               </div>
             </div>

--- a/app/app/views/cbv/submits/_paystubs_cover_page.pdf.erb
+++ b/app/app/views/cbv/submits/_paystubs_cover_page.pdf.erb
@@ -10,9 +10,9 @@
       <% if current_agency.logo_path.present? %>
         <div class="display-inline-block text-middle">
           <% if current_agency.logo_path.start_with?("http", "data:") %>
-            <%= image_tag current_agency.logo_path, class: "cbv-header__agency-logo--#{current_agency.id}" %>
+            <%= image_tag current_agency.logo_path, class: "cbv-header__agency-logo--#{current_agency.id}", alt: agency_logo_alt_text %>
           <% else %>
-            <%= image_tag wicked_pdf_asset_base64(current_agency.logo_path), class: "cbv-header__agency-logo--#{current_agency.id}" %>
+            <%= image_tag wicked_pdf_asset_base64(current_agency.logo_path), class: "cbv-header__agency-logo--#{current_agency.id}", alt: agency_logo_alt_text %>
           <% end %>
         </div>
       <% else %>

--- a/app/app/views/shared/_pdf_report_header.pdf.erb
+++ b/app/app/views/shared/_pdf_report_header.pdf.erb
@@ -9,9 +9,9 @@
     <% if current_agency.logo_path.present? %>
       <div class="display-inline-block text-middle">
         <% if current_agency.logo_path.start_with?("http", "data:") %>
-          <%= image_tag current_agency.logo_path, class: "cbv-header__agency-logo--#{current_agency.id}" %>
+          <%= image_tag current_agency.logo_path, class: "cbv-header__agency-logo--#{current_agency.id}", alt: agency_logo_alt_text %>
         <% else %>
-          <%= image_tag wicked_pdf_asset_base64(current_agency.logo_path), class: "cbv-header__agency-logo--#{current_agency.id}" %>
+          <%= image_tag wicked_pdf_asset_base64(current_agency.logo_path), class: "cbv-header__agency-logo--#{current_agency.id}", alt: agency_logo_alt_text %>
         <% end %>
       </div>
     <% else %>

--- a/app/spec/helpers/application_helper_spec.rb
+++ b/app/spec/helpers/application_helper_spec.rb
@@ -185,6 +185,29 @@ RSpec.describe ApplicationHelper do
     end
   end
 
+  describe "#agency_logo_alt_text" do
+    before do
+      allow(helper).to receive(:agency_translation).with("shared.agency_full_name").and_return("Full Agency Name")
+      allow(helper).to receive(:agency_translation).with("shared.agency_acronym").and_return(acronym)
+    end
+
+    context "when the partner has an acronym" do
+      let(:acronym) { "DHS" }
+
+      it "returns the acronym followed by 'Logo'" do
+        expect(helper.agency_logo_alt_text).to eq("DHS Logo")
+      end
+    end
+
+    context "when the partner has no acronym" do
+      let(:acronym) { nil }
+
+      it "falls back to the full agency name followed by 'Logo'" do
+        expect(helper.agency_logo_alt_text).to eq("Full Agency Name Logo")
+      end
+    end
+  end
+
   describe "#agency_website_link" do
     let(:url) { "https://compass.example.gov" }
     let(:current_agency) do


### PR DESCRIPTION
## Summary
- Fixing alt text for agency header logos using a helper function to standardize usage.
    - **ISSUE:** Header logo rendered in multiple locations with inconsistent use of alt text
- Marking company select logos as decorative with empty alt text
    - **ISSUE:** alt text was explicitly set to "Placeholder alt text"

## Type of Change
Check all that apply.
- [x] Bug
- [ ] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
- Added `agency_logo_alt_text` as an application helper and used it in both the main header, and for pdf headers. 
- Modified hardcoded alt text of "A placeholder image" to be empty string --> indicates to Assistive Technology this is a decorative image. 

## Checklist
- [x] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
[if anything need special attention, note it here]
