### PR TITLE
Drew/pf 763 669 logo alt text refactor

### DIFF
--- a/app/app/helpers/application_helper.rb
+++ b/app/app/helpers/application_helper.rb
@@ -100,6 +100,11 @@ module ApplicationHelper
     "#{full_name} (#{agency_translation("shared.agency_acronym")})"
   end
 
+  # Alt text for the agency logo image (e.g. "DHS Logo" / "DES/FAA Logo").
+  def agency_logo_alt_text
+    t("shared.header.logo_alt", agency_acronym: agency_acronym_or_full_name)
+  end
+
   # A reusable anchor tag to the agency portal
   def agency_website_link(label: agency_website_link_label)
     url = current_agency&.agency_contact_website

--- a/app/app/views/application/_header.html.erb
+++ b/app/app/views/application/_header.html.erb
@@ -19,26 +19,15 @@
           </div>
 
           <% has_logo = current_agency && current_agency.logo_path.present? %>
-          <% has_square_logo = current_agency && current_agency.logo_square_path.present? %>
-          <% logo_path = has_square_logo ? current_agency.logo_square_path : (has_logo ? current_agency.logo_path : nil) %>
-          <% show_agency_text = has_square_logo || !has_logo %>
 
-          <div class="<%= has_logo ?
-            "display-none tablet:display-flex" : "display-flex" %> flex-align-center">
-            <% if logo_path %>
-              <%= image_tag logo_path, class: "cbv-header__agency-logo cbv-header__agency-logo--#{current_agency.id}",
-                            alt: "#{agency_acronym_or_full_name} Logo",
-                            title: "#{agency_acronym_or_full_name} Logo" %>
-            <% end %>
-
-            <% if show_agency_text %>
+          <div class="flex-align-center">
+            <% if has_logo %>
+              <%= image_tag current_agency.logo_path, class: "cbv-header__agency-logo cbv-header__agency-logo--#{current_agency.id}",
+                            alt: agency_logo_alt_text %>
+            <% else %>
               <%= agency_translation("shared.header.cbv_flow_title") %>
             <% end %>
           </div>
-
-          <% if has_logo %>
-            <%= image_tag current_agency.logo_path, class: "cbv-header__agency-logo cbv-header__agency-logo--#{current_agency.id} tablet:display-none" %>
-          <% end %>
         </em>
       </div>
 

--- a/app/app/views/cbv/employer_searches/_employer.html.erb
+++ b/app/app/views/cbv/employer_searches/_employer.html.erb
@@ -20,7 +20,7 @@
               <div class="usa-card__img cbv-employer-card__img">
                 <img
                   src="<%= employer.logo_url.sub(/^http:/, "https:") %>"
-                  alt="A placeholder image"
+                  alt="" # NOTE: Intentionally left blank to mark as decorative image
                 >
               </div>
             </div>

--- a/app/app/views/cbv/submits/_paystubs_cover_page.pdf.erb
+++ b/app/app/views/cbv/submits/_paystubs_cover_page.pdf.erb
@@ -10,9 +10,9 @@
       <% if current_agency.logo_path.present? %>
         <div class="display-inline-block text-middle">
           <% if current_agency.logo_path.start_with?("http", "data:") %>
-            <%= image_tag current_agency.logo_path, class: "cbv-header__agency-logo--#{current_agency.id}" %>
+            <%= image_tag current_agency.logo_path, class: "cbv-header__agency-logo--#{current_agency.id}", alt: agency_logo_alt_text %>
           <% else %>
-            <%= image_tag wicked_pdf_asset_base64(current_agency.logo_path), class: "cbv-header__agency-logo--#{current_agency.id}" %>
+            <%= image_tag wicked_pdf_asset_base64(current_agency.logo_path), class: "cbv-header__agency-logo--#{current_agency.id}", alt: agency_logo_alt_text %>
           <% end %>
         </div>
       <% else %>

--- a/app/app/views/shared/_pdf_report_header.pdf.erb
+++ b/app/app/views/shared/_pdf_report_header.pdf.erb
@@ -9,9 +9,9 @@
     <% if current_agency.logo_path.present? %>
       <div class="display-inline-block text-middle">
         <% if current_agency.logo_path.start_with?("http", "data:") %>
-          <%= image_tag current_agency.logo_path, class: "cbv-header__agency-logo--#{current_agency.id}" %>
+          <%= image_tag current_agency.logo_path, class: "cbv-header__agency-logo--#{current_agency.id}", alt: agency_logo_alt_text %>
         <% else %>
-          <%= image_tag wicked_pdf_asset_base64(current_agency.logo_path), class: "cbv-header__agency-logo--#{current_agency.id}" %>
+          <%= image_tag wicked_pdf_asset_base64(current_agency.logo_path), class: "cbv-header__agency-logo--#{current_agency.id}", alt: agency_logo_alt_text %>
         <% end %>
       </div>
     <% else %>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -802,6 +802,7 @@ en:
       close: Close
       help: Help
       log_out: Log out
+      logo_alt: "%{agency_acronym} Logo"
       preheader:
         default: A website in partnership with CBV Test Agency.
         la_ldh: A website in partnership with the Louisiana Department of Health

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -734,6 +734,7 @@ es:
       close: Cerrar
       help: Ayuda
       log_out: Cerrar sesión
+      logo_alt: Logo de %{agency_acronym}
       preheader:
         default: Un sitio web en colaboración con la Agencia de pruebas CBV.
         la_ldh: Un sitio web en colaboración con el Departamento de Salud de Luisiana

--- a/app/lib/client_agency_config.rb
+++ b/app/lib/client_agency_config.rb
@@ -259,7 +259,6 @@ class ClientAgencyConfig
       include_direct_deposit_last_4
       invitation_valid_days
       logo_path
-      logo_square_path
       pay_income_days
       pinwheel_api_token
       pinwheel_environment

--- a/app/spec/helpers/application_helper_spec.rb
+++ b/app/spec/helpers/application_helper_spec.rb
@@ -185,6 +185,29 @@ RSpec.describe ApplicationHelper do
     end
   end
 
+  describe "#agency_logo_alt_text" do
+    before do
+      allow(helper).to receive(:agency_translation).with("shared.agency_full_name").and_return("Full Agency Name")
+      allow(helper).to receive(:agency_translation).with("shared.agency_acronym").and_return(acronym)
+    end
+
+    context "when the partner has an acronym" do
+      let(:acronym) { "DHS" }
+
+      it "interpolates the acronym into the shared.header.logo_alt translation" do
+        expect(helper.agency_logo_alt_text).to eq("DHS Logo")
+      end
+    end
+
+    context "when the partner has no acronym" do
+      let(:acronym) { nil }
+
+      it "falls back to the full agency name" do
+        expect(helper.agency_logo_alt_text).to eq("Full Agency Name Logo")
+      end
+    end
+  end
+
   describe "#agency_website_link" do
     let(:url) { "https://compass.example.gov" }
     let(:current_agency) do


### PR DESCRIPTION
## Summary
- Fixing alt text for agency header logos using a helper function to standardize usage.
    - **ISSUE:** Header logo rendered in multiple locations with inconsistent use of alt text
- Marking company select logos as decorative with empty alt text
    - **ISSUE:** alt text was explicitly set to "Placeholder alt text"

## Type of Change
Check all that apply.
- [x] Bug
- [ ] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
- Removed square logo logic which helped remove redundant renders of agency logo image
- Created i18n config option for agency logo alt text
- Added `agency_logo_alt_text` as an application helper and used it in both the main header, and for pdf headers. 
- Modified hardcoded alt text of "A placeholder image" to be empty string --> indicates to Assistive Technology this is a decorative image. 

## Checklist
- [x] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
[if anything need special attention, note it here]
