### PR TITLE
Add descriptive accessible names to Review income report Edit links

### DIFF
--- a/app/app/helpers/application_helper.rb
+++ b/app/app/helpers/application_helper.rb
@@ -100,6 +100,12 @@ module ApplicationHelper
     "#{full_name} (#{agency_translation("shared.agency_acronym")})"
   end
 
+  # A visually-hidden span used to add descriptive context to an otherwise
+  # generic visible label (e.g. "Edit" -> "Edit Applicant information").
+  def sr_only_span(text)
+    content_tag(:span, text, class: "usa-sr-only")
+  end
+
   # A reusable anchor tag to the agency portal
   def agency_website_link(label: agency_website_link_label)
     url = current_agency&.agency_contact_website

--- a/app/app/views/cbv/employer_searches/_employer.html.erb
+++ b/app/app/views/cbv/employer_searches/_employer.html.erb
@@ -38,7 +38,7 @@
               type="button"
             >
               <%= t("cbv.employer_searches.show.select") %>
-              <span class="usa-sr-only"><%= employer.name %></span>
+              <%= sr_only_span(employer.name) %>
             </button>
           </div>
         </div>

--- a/app/app/views/cbv/summaries/show.html.erb
+++ b/app/app/views/cbv/summaries/show.html.erb
@@ -39,7 +39,10 @@
 <p><%= agency_translation(".must_match", agency_acronym: agency_acronym_or_full_name) %></p>
 <div class="display-flex flex-justify font-body-md">
   <h3><%= t(".application_information") %></h3>
-  <%= link_to t(".edit"), cbv_flow_applicant_information_path(force_show: true), class: "usa-link text-bold margin-0" %>
+  <%= link_to cbv_flow_applicant_information_path(force_show: true), class: "usa-link text-bold margin-0" do %>
+    <%= t(".edit") %>
+    <%= sr_only_span(t(".application_information")) %>
+  <% end %>
 </div>
 <%= render(TableComponent.new(is_responsive: true, class_names: "margin-top-2", thead_class_names: "", attributes: { "data-testid" => "paystub-table" })) do |table| %>
   <%= table.with_subheader_row(class_names: "subheader-row base-lightest border-top-1px") do |row| %>
@@ -64,7 +67,10 @@
 <!-- Other jobs -->
 <div class="display-flex flex-justify font-body-md">
   <h3><%= t("cbv.summaries.show.other_jobs") %></h3>
-  <%= link_to t("cbv.summaries.show.edit"), cbv_flow_other_job_path(return_to_path: request.fullpath), class: "usa-link text-bold margin-0" %>
+  <%= link_to cbv_flow_other_job_path(return_to_path: request.fullpath), class: "usa-link text-bold margin-0" do %>
+    <%= t("cbv.summaries.show.edit") %>
+    <%= sr_only_span(t("cbv.summaries.show.other_jobs")) %>
+  <% end %>
 </div>
 <%= render(TableComponent.new(is_responsive: true, class_names: "margin-top-2", thead_class_names: "", attributes: { "data-testid" => "other-jobs-table" })) do |table| %>
   <%= table.with_subheader_row(class_names: "subheader-row base-lightest border-top-1px") do |row| %>


### PR DESCRIPTION
## Summary
- On the Generic flow's "Review your income report" step, the "Applicant information" and "Other jobs" Edit links only announced "Edit" to screen readers, giving no indication of what they'd edit (fails WCAG 2.4.9 Link Purpose).
- Added a visually-hidden `usa-sr-only` span with the section name to each link so the accessible name is now "Edit Applicant information" / "Edit Other jobs", while the visible label stays "Edit". Reuses the existing `application_information`/`other_jobs` translation keys, so no new i18n keys or es.yml changes were needed.
- Extracted a small `sr_only_span` helper (`app/helpers/application_helper.rb`) for this "visible short label + hidden descriptive span" pattern, and migrated the pre-existing identical inline span in the employer search "Select" button to use it too, for consistency.

## Test plan
- [x] `rubocop` clean on the changed Ruby/helper file
- [x] `erb_lint` clean on both changed `.erb` files
- [x] Confirmed no existing specs assert on the literal "Edit" link text
- [ ] Manually verify in a browser accessibility inspector that the two Edit links on the Review step report accessible names "Edit Applicant information" and "Edit Other jobs" (could not run the full RSpec suite in this environment — no local Postgres/docker available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)