### PR TITLE
Generic 'Edit" link text on Summary page

### DIFF
--- a/app/app/helpers/application_helper.rb
+++ b/app/app/helpers/application_helper.rb
@@ -100,6 +100,12 @@ module ApplicationHelper
     "#{full_name} (#{agency_translation("shared.agency_acronym")})"
   end
 
+  # A visually-hidden span used to add descriptive context to an otherwise
+  # generic visible label (e.g. "Edit" -> "Edit Applicant information").
+  def sr_only_span(text)
+    content_tag(:span, text, class: "usa-sr-only")
+  end
+
   # A reusable anchor tag to the agency portal
   def agency_website_link(label: agency_website_link_label)
     url = current_agency&.agency_contact_website

--- a/app/app/helpers/application_helper.rb
+++ b/app/app/helpers/application_helper.rb
@@ -105,7 +105,7 @@ module ApplicationHelper
   def sr_only_span(text)
     content_tag(:span, text, class: "usa-sr-only")
   end
-  
+
   # Alt text for the agency logo image (e.g. "DHS Logo").
   def agency_logo_alt_text
     "#{agency_acronym_or_full_name} Logo"

--- a/app/app/views/cbv/employer_searches/_employer.html.erb
+++ b/app/app/views/cbv/employer_searches/_employer.html.erb
@@ -38,7 +38,7 @@
               type="button"
             >
               <%= t("cbv.employer_searches.show.select") %>
-              <span class="usa-sr-only"><%= employer.name %></span>
+              <%= sr_only_span(employer.name) %>
             </button>
           </div>
         </div>

--- a/app/app/views/cbv/summaries/show.html.erb
+++ b/app/app/views/cbv/summaries/show.html.erb
@@ -39,7 +39,10 @@
 <p><%= agency_translation(".must_match", agency_acronym: agency_acronym_or_full_name) %></p>
 <div class="display-flex flex-justify font-body-md">
   <h3><%= t(".application_information") %></h3>
-  <%= link_to t(".edit"), cbv_flow_applicant_information_path(force_show: true), class: "usa-link text-bold margin-0" %>
+  <%= link_to cbv_flow_applicant_information_path(force_show: true), class: "usa-link text-bold margin-0" do %>
+    <%= t(".edit") %>
+    <%= sr_only_span(t(".application_information")) %>
+  <% end %>
 </div>
 <%= render(TableComponent.new(is_responsive: true, class_names: "margin-top-2", thead_class_names: "", attributes: { "data-testid" => "paystub-table" })) do |table| %>
   <%= table.with_subheader_row(class_names: "subheader-row base-lightest border-top-1px") do |row| %>
@@ -64,7 +67,10 @@
 <!-- Other jobs -->
 <div class="display-flex flex-justify font-body-md">
   <h3><%= t("cbv.summaries.show.other_jobs") %></h3>
-  <%= link_to t("cbv.summaries.show.edit"), cbv_flow_other_job_path(return_to_path: request.fullpath), class: "usa-link text-bold margin-0" %>
+  <%= link_to cbv_flow_other_job_path(return_to_path: request.fullpath), class: "usa-link text-bold margin-0" do %>
+    <%= t("cbv.summaries.show.edit") %>
+    <%= sr_only_span(t("cbv.summaries.show.other_jobs")) %>
+  <% end %>
 </div>
 <%= render(TableComponent.new(is_responsive: true, class_names: "margin-top-2", thead_class_names: "", attributes: { "data-testid" => "other-jobs-table" })) do |table| %>
   <%= table.with_subheader_row(class_names: "subheader-row base-lightest border-top-1px") do |row| %>


### PR DESCRIPTION
## Summary
Fixes non-descriptive "Edit" links in the "Review your income report" step where screen reader users tabbing to the "Applicant information" and "Other jobs" Edit links only heard "Edit" with no indication of what they'd edit.

## Type of Change
Check all that apply.
- [x] Bug
- [ ] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
- Added a `sr_only_span(text)` helper in `app/helpers/application_helper.rb` that wraps text in a visually-hidden `usa-sr-only` span, for augmenting a short visible label with descriptive context for screen readers.
- Updated the "Applicant information" Edit link in `app/views/` to include a hidden span so its accessible name is "Edit Applicant information" (visible text still just "Edit").
- Updated the "Other jobs" Edit link in the same file so it reads "Edit other jobs".
- Migrated the existing employer search "Select" button (`app/views/cbv/employer_searches/_employer.html.erb`) to use the new `sr_only_span` helper instead of its inline `usa-sr-only` span, consolidating the pattern in one place.
- No new i18n keys needed — both edit links reuse the existing `application_information`/`other_jobs` translation keys for the hidden text, so Spanish translations come along for free.

## Checklist
- [ ] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers

### Other Jobs Link

<img width="1643" height="340" alt="Screenshot 2026-07-09 131412" src="https://github.com/user-attachments/assets/c69a4c4d-ae28-41d1-a12c-5d8148dcb1aa" />

### Applicant Information link
<img width="1620" height="458" alt="Screenshot 2026-07-09 131444" src="https://github.com/user-attachments/assets/92d0588c-58e0-44cf-bddf-865f49d257a0" />
