### PR TITLE
PF-742: Clearing text from company search

### DIFF
--- a/app/app/assets/stylesheets/cbv.scss
+++ b/app/app/assets/stylesheets/cbv.scss
@@ -373,3 +373,41 @@ input#invitation_link {
 .usa-list--explainer li {
   margin-bottom: 1rem;
 }
+
+/*
+ * Employer search — accessible clear button
+ */
+ .cbv-employer-search__input-wrapper {
+  position: relative;
+  display: flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: units($theme-input-max-width);
+
+  .usa-input {
+    flex: 1 1 auto;
+    min-width: 0;
+    padding-right: units(5);
+
+    &::-webkit-search-cancel-button,
+    &::-webkit-search-decoration {
+      -webkit-appearance: none;
+      appearance: none;
+    }
+
+    &::-ms-clear {
+      display: none;
+    }
+  }
+}
+
+.cbv-employer-search__clear-button {
+  position: absolute;
+  top: 50%;
+  right: units(1);
+  transform: translateY(-50%);
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}

--- a/app/app/javascript/controllers/cbv/employer_search.js
+++ b/app/app/javascript/controllers/cbv/employer_search.js
@@ -3,7 +3,14 @@ import { createModalAdapter } from "@js/utilities/createModalAdapter"
 import { loadProviderResources } from "@js/utilities/loadProviderResources.ts"
 
 export default class extends Controller {
-  static targets = ["form", "userAccountId", "employerButton", "helpAlert"]
+  static targets = [
+    "form",
+    "userAccountId",
+    "employerButton",
+    "helpAlert",
+    "queryInput",
+    "clearButton",
+  ]
 
   static values = {
     cbvFlowId: Number,
@@ -35,6 +42,15 @@ export default class extends Controller {
     const submitter = event.detail.formSubmission?.submitter
 
     if (submitter) submitter.disabled = false
+  }
+
+  toggleClearButton() {
+    this.clearButtonTarget.hidden = this.queryInputTarget.value.length === 0
+  }
+
+  onSearchReset() {
+    this.clearButtonTarget.hidden = true
+    this.queryInputTarget.focus()
   }
 
   onSuccess(accountId) {

--- a/app/app/javascript/controllers/cbv/employer_search.js
+++ b/app/app/javascript/controllers/cbv/employer_search.js
@@ -48,7 +48,9 @@ export default class extends Controller {
     this.clearButtonTarget.hidden = this.queryInputTarget.value.length === 0
   }
 
-  onSearchReset() {
+  onSearchReset(event) {
+    event.preventDefault()
+    this.queryInputTarget.value = ""
     this.clearButtonTarget.hidden = true
     this.queryInputTarget.focus()
   }

--- a/app/app/views/cbv/employer_searches/show.html.erb
+++ b/app/app/views/cbv/employer_searches/show.html.erb
@@ -37,7 +37,7 @@
         class="cbv-employer-search__clear-button"
         <%= "hidden" if @query.blank? %>
         data-cbv-employer-search-target="clearButton">
-        <span class="usa-sr-only"><%= t(".clear_search") %></span>
+        <%= sr_only_span( t(".clear_search")) %>
         <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
           <use href="<%= asset_path("@uswds/uswds/dist/img/sprite.svg#close") %>"></use>
         </svg>

--- a/app/app/views/cbv/employer_searches/show.html.erb
+++ b/app/app/views/cbv/employer_searches/show.html.erb
@@ -27,8 +27,22 @@
 
   <div id="company_examples" class="text-gray-50"><%= t(".company_examples") %></div>
 
-  <%= form_with url: cbv_flow_employer_search_path, method: :get, class: "usa-search usa-search--big margin-bottom-4 margin-top-2", html: { role: "search" }, data: { turbo_frame: "employers", turbo_action: "advance" } do |f| %>
-    <%= f.text_field :query, value: @query, class: "usa-input", type: "search", aria: { describedby: "company_examples" } %>
+  <%= form_with url: cbv_flow_employer_search_path, method: :get, class: "usa-search usa-search--big margin-bottom-4 margin-top-2", html: { role: "search" }, data: { turbo_frame: "employers", turbo_action: "advance", action: "reset->cbv-employer-search#onSearchReset" } do |f| %>
+    <div class="cbv-employer-search__input-wrapper">
+      <%= f.text_field :query, value: @query, class: "usa-input", type: "search",
+            aria: { describedby: "company_examples" },
+            data: { "cbv-employer-search-target": "queryInput", action: "input->cbv-employer-search#toggleClearButton" } %>
+      <button
+        type="reset"
+        class="cbv-employer-search__clear-button"
+        <%= "hidden" if @query.blank? %>
+        data-cbv-employer-search-target="clearButton">
+        <span class="usa-sr-only"><%= t(".clear_search") %></span>
+        <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+          <use href="<%= asset_path("@uswds/uswds/dist/img/sprite.svg#close") %>"></use>
+        </svg>
+      </button>
+    </div>
     <button
       class="usa-button"
       type="submit">

--- a/app/app/views/cbv/employer_searches/show.html.erb
+++ b/app/app/views/cbv/employer_searches/show.html.erb
@@ -37,7 +37,7 @@
         class="cbv-employer-search__clear-button"
         <%= "hidden" if @query.blank? %>
         data-cbv-employer-search-target="clearButton">
-        <%= sr_only_span( t(".clear_search")) %>
+        <%= sr_only_span(t(".clear_search")) %>
         <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
           <use href="<%= asset_path("@uswds/uswds/dist/img/sprite.svg#close") %>"></use>
         </svg>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -266,6 +266,7 @@ en:
           help_options: Get help here.
         app_based_providers: App-based employers
         can_not_find_employer: Explore your options
+        clear_search: Clear search
         company_examples: 'Examples: Uber, McDonald''s, ADP'
         company_name: Company Name
         employer_not_listed: Trouble finding your employer or payroll provider?

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -168,6 +168,7 @@ es:
           help_options: Obtenga ayuda aquí.
         app_based_providers: Empleadores basados
         can_not_find_employer: Explore sus opciones
+        clear_search: Borrar búsqueda
         company_examples: 'Ejemplos: Uber, McDonald''s, ADP'
         company_name: Nombre de la empresa
         employer_not_listed: "¿Tiene problemas para encontrar a su empleador o proveedor de nómina?"

--- a/app/spec/javascript/controllers/employer_search.spec.js
+++ b/app/spec/javascript/controllers/employer_search.spec.js
@@ -177,6 +177,71 @@ describe("EmployerSearchController onSearchStart", () => {
   })
 })
 
+describe("EmployerSearchController clear button", () => {
+  let controllerElement
+  let form
+  let queryInput
+  let clearButton
+
+  beforeEach(async () => {
+    controllerElement = document.createElement("div")
+    controllerElement.setAttribute("data-controller", "cbv-employer-search")
+
+    form = document.createElement("form")
+    form.setAttribute("data-action", "reset->cbv-employer-search#onSearchReset")
+
+    queryInput = document.createElement("input")
+    queryInput.setAttribute("type", "search")
+    queryInput.setAttribute("data-cbv-employer-search-target", "queryInput")
+    queryInput.setAttribute("data-action", "input->cbv-employer-search#toggleClearButton")
+
+    clearButton = document.createElement("button")
+    clearButton.setAttribute("type", "reset")
+    clearButton.setAttribute("data-cbv-employer-search-target", "clearButton")
+    clearButton.hidden = true
+
+    form.appendChild(queryInput)
+    form.appendChild(clearButton)
+    controllerElement.appendChild(form)
+    document.body.appendChild(controllerElement)
+
+    await window.Stimulus.register("cbv-employer-search", EmployerSearchController)
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  it("shows the clear button once the query input has a value", () => {
+    queryInput.value = "Walmart"
+    queryInput.dispatchEvent(new Event("input", { bubbles: true }))
+
+    expect(clearButton.hidden).toBe(false)
+  })
+
+  it("hides the clear button again once the query input is emptied", () => {
+    queryInput.value = "Walmart"
+    queryInput.dispatchEvent(new Event("input", { bubbles: true }))
+    expect(clearButton.hidden).toBe(false)
+
+    queryInput.value = ""
+    queryInput.dispatchEvent(new Event("input", { bubbles: true }))
+
+    expect(clearButton.hidden).toBe(true)
+  })
+
+  it("hides the clear button and refocuses the input when the form is reset", () => {
+    queryInput.value = "Walmart"
+    queryInput.dispatchEvent(new Event("input", { bubbles: true }))
+    expect(clearButton.hidden).toBe(false)
+
+    form.dispatchEvent(new Event("reset", { bubbles: true }))
+
+    expect(clearButton.hidden).toBe(true)
+    expect(document.activeElement).toBe(queryInput)
+  })
+})
+
 describe("EmployerSearchController multiple instances on same page!", () => {
   let stimulusElement1
   let stimulusElement2

--- a/app/spec/javascript/controllers/employer_search.spec.js
+++ b/app/spec/javascript/controllers/employer_search.spec.js
@@ -240,6 +240,18 @@ describe("EmployerSearchController clear button", () => {
     expect(clearButton.hidden).toBe(true)
     expect(document.activeElement).toBe(queryInput)
   })
+
+  it("empties the input on reset even when it was pre-filled from a query param", () => {
+    // Simulates the server rendering `value: @query`, which becomes the
+    // input's defaultValue that a native form reset would otherwise restore.
+    queryInput.setAttribute("value", "Walmart")
+    queryInput.value = "Walmart"
+    queryInput.dispatchEvent(new Event("input", { bubbles: true }))
+
+    form.dispatchEvent(new Event("reset", { bubbles: true, cancelable: true }))
+
+    expect(queryInput.value).toBe("")
+  })
 })
 
 describe("EmployerSearchController multiple instances on same page!", () => {


### PR DESCRIPTION
## Summary
USWDS search box does not have a built in clear search button and instead relied on the browser's native search cancel button, a feature that is inconsistently applied across browsers and which cannot be reached via keyboard or screen-reader navigation. Replaced it with a real, keyboard-focusable button and disabled showing browser native clear buttons.

## Type of Change
Check all that apply.
- [x] Bug
- [ ] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
- Added `clear_search` translation key (`en.yml`, `es.yml`)
- Wrapped the employer search `<input type="search">` and added a real `<button type="reset">` clear button with `usa-sr-only` accessible text, instead of relying on the browser's native (mouse/tap-only) clear icon
- Added `toggleClearButton` (show/hide the button as the user types) and `onSearchReset` (hide the button and refocus the input after reset, since form reset doesn't fire an `input` event) to the `cbv-employer-search` Stimulus controller
- Suppressed the native `::-webkit-search-cancel-button`/`::-ms-clear` icons via CSS so only the new accessible button is shown

## Checklist
- [x] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviews

https://github.com/user-attachments/assets/80408c54-4e25-4c61-b4c4-f99848c7b1dd
