### PR TITLE
PF-743: employer search error handling for empty string

### DIFF
--- a/app/app/javascript/controllers/cbv/employer_search.js
+++ b/app/app/javascript/controllers/cbv/employer_search.js
@@ -67,51 +67,51 @@ export default class extends Controller {
     }
   }
 
-  toggleErrorIds(target, error) {
+  toggleErrorIds(target, error, id) {
+    const describedbyList = target.getAttribute("aria-describedby")
+    if (error && describedbyList.includes(id)) return
     let describeIds;
 
+    // TODO: DREW - should error id be first or second?
     if(error) {
-      describeIds = "query_error_message" + " " + target.getAttribute("aria-describedby")
+      describeIds = id + " " + describedbyList
     } else {
-      describeIds = target.getAttribute("aria-describedby").replace("query_error_message", "").trim()
+      describeIds = describedbyList.replace(id, "").trim()
     }
 
-    this.queryInputTarget.setAttribute("aria-describedby", describeIds)
+    target.setAttribute("aria-describedby", describeIds)
+  }
+
+  updateAriaLiveRegion(text) {
+    document.getElementById("live-announcer").replaceChildren()
+    if (text) {
+      document.getElementById("live-announcer").textContent = text
+    }
   }
 
   showError() {
-    // const ariaLiveRegion = document.getElementById("live-announcer")
-    // ariaLiveRegion.replaceChildren()
-    // const pTag = document.createElement('p')
-    document.getElementById("query_error_message").replaceChildren()
-    document.getElementById("query_error_message").textContent = "HELLO WORLD"
-    // pTag.textContent ="HELLO WORLD"
-    // console.log("DROO", ariaLiveRegion)
-    // console.log("DROO", pTag)
-
-    // ariaLiveRegion.appendChild(pTag)
+    // announce to the user the error message
+    this.updateAriaLiveRegion(this.errorMessageTarget.textContent)
+    // visually show the error message
     this.errorMessageTarget.classList.remove("display-none")
+    // visually and programatically change the input to be in an error state, associate message with input
     this.queryInputTarget.classList.add("usa-input--error")
     this.queryInputTarget.setAttribute("aria-invalid", "true")
-    this.toggleErrorIds(this.queryInputTarget, true)
+    this.toggleErrorIds(this.queryInputTarget, true, "query_error_message")
+    // prevent error message from making content jump
     this.searchFormTarget.classList.remove("margin-bottom-4")
   }
 
   hideError() {
-    document.getElementById("query_error_message").replaceChildren()
-    document.getElementById("query_error_message").textContent = "GOODBYE WORLD"
-    // const ariaLiveRegion = document.getElementById("live-announcer")
-    // ariaLiveRegion.replaceChildren()
-    // const pTag = document.createElement('p')
-    // pTag.textContent ="GOODBYE WORLD"
-    // console.log("DROO", ariaLiveRegion)
-    // console.log("DROO", pTag)
-
-    // ariaLiveRegion.appendChild(pTag)
+    // clear error message from live region
+    this.updateAriaLiveRegion()
+    // visually hide error message
     this.errorMessageTarget.classList.add("display-none")
+    // visually and programatically remove input error state and associations 
     this.queryInputTarget.classList.remove("usa-input--error")
     this.queryInputTarget.removeAttribute("aria-invalid")
-    this.toggleErrorIds(this.queryInputTarget, false)
+    this.toggleErrorIds(this.queryInputTarget, false, "query_error_message")
+    // revert styling 
     this.searchFormTarget.classList.add("margin-bottom-4")
   }
 

--- a/app/app/javascript/controllers/cbv/employer_search.js
+++ b/app/app/javascript/controllers/cbv/employer_search.js
@@ -1,6 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 import { createModalAdapter } from "@js/utilities/createModalAdapter"
 import { loadProviderResources } from "@js/utilities/loadProviderResources.ts"
+import { toggleErrorIds, updateAriaLiveRegion } from "@js/utilities/accessibility"
 
 export default class extends Controller {
   static targets = [
@@ -67,50 +68,28 @@ export default class extends Controller {
     }
   }
 
-  toggleErrorIds(target, error, id) {
-    const describedbyList = target.getAttribute("aria-describedby")
-    if (error && describedbyList.includes(id)) return
-    let describeIds
-
-    // TODO: DREW - should error id be first or second?
-    if (error) {
-      describeIds = id + " " + describedbyList
-    } else {
-      describeIds = describedbyList.replace(id, "").trim()
-    }
-
-    target.setAttribute("aria-describedby", describeIds)
-  }
-
-  updateAriaLiveRegion(text) {
-    document.getElementById("live-announcer").replaceChildren()
-    if (text) {
-      document.getElementById("live-announcer").textContent = text
-    }
-  }
-
   showError() {
     // announce to the user the error message
-    this.updateAriaLiveRegion(this.errorMessageTarget.textContent)
+    updateAriaLiveRegion(this.errorMessageTarget.textContent)
     // visually show the error message
     this.errorMessageTarget.classList.remove("display-none")
     // visually and programatically change the input to be in an error state, associate message with input
     this.queryInputTarget.classList.add("usa-input--error")
     this.queryInputTarget.setAttribute("aria-invalid", "true")
-    this.toggleErrorIds(this.queryInputTarget, true, "query_error_message")
+    toggleErrorIds(this.queryInputTarget, true, "query_error_message")
     // prevent error message from making content jump
     this.searchFormTarget.classList.remove("margin-bottom-4")
   }
 
   hideError() {
     // clear error message from live region
-    this.updateAriaLiveRegion()
+    updateAriaLiveRegion()
     // visually hide error message
     this.errorMessageTarget.classList.add("display-none")
     // visually and programatically remove input error state and associations
     this.queryInputTarget.classList.remove("usa-input--error")
     this.queryInputTarget.removeAttribute("aria-invalid")
-    this.toggleErrorIds(this.queryInputTarget, false, "query_error_message")
+    toggleErrorIds(this.queryInputTarget, false, "query_error_message")
     // revert styling
     this.searchFormTarget.classList.add("margin-bottom-4")
   }

--- a/app/app/javascript/controllers/cbv/employer_search.js
+++ b/app/app/javascript/controllers/cbv/employer_search.js
@@ -70,10 +70,10 @@ export default class extends Controller {
   toggleErrorIds(target, error, id) {
     const describedbyList = target.getAttribute("aria-describedby")
     if (error && describedbyList.includes(id)) return
-    let describeIds;
+    let describeIds
 
     // TODO: DREW - should error id be first or second?
-    if(error) {
+    if (error) {
       describeIds = id + " " + describedbyList
     } else {
       describeIds = describedbyList.replace(id, "").trim()
@@ -107,11 +107,11 @@ export default class extends Controller {
     this.updateAriaLiveRegion()
     // visually hide error message
     this.errorMessageTarget.classList.add("display-none")
-    // visually and programatically remove input error state and associations 
+    // visually and programatically remove input error state and associations
     this.queryInputTarget.classList.remove("usa-input--error")
     this.queryInputTarget.removeAttribute("aria-invalid")
     this.toggleErrorIds(this.queryInputTarget, false, "query_error_message")
-    // revert styling 
+    // revert styling
     this.searchFormTarget.classList.add("margin-bottom-4")
   }
 

--- a/app/app/javascript/controllers/cbv/employer_search.js
+++ b/app/app/javascript/controllers/cbv/employer_search.js
@@ -10,6 +10,8 @@ export default class extends Controller {
     "helpAlert",
     "queryInput",
     "clearButton",
+    "errorMessage",
+    "searchForm",
   ]
 
   static values = {
@@ -46,6 +48,7 @@ export default class extends Controller {
 
   toggleClearButton() {
     this.clearButtonTarget.hidden = this.queryInputTarget.value.length === 0
+    if (this.queryInputTarget.value.length > 0) this.hideError()
   }
 
   onSearchReset(event) {
@@ -53,6 +56,63 @@ export default class extends Controller {
     this.queryInputTarget.value = ""
     this.clearButtonTarget.hidden = true
     this.queryInputTarget.focus()
+  }
+
+  onSubmit(event) {
+    if (this.queryInputTarget.value.trim().length === 0) {
+      event.preventDefault()
+      this.showError()
+    } else {
+      this.hideError()
+    }
+  }
+
+  toggleErrorIds(target, error) {
+    let describeIds;
+
+    if(error) {
+      describeIds = "query_error_message" + " " + target.getAttribute("aria-describedby")
+    } else {
+      describeIds = target.getAttribute("aria-describedby").replace("query_error_message", "").trim()
+    }
+
+    this.queryInputTarget.setAttribute("aria-describedby", describeIds)
+  }
+
+  showError() {
+    // const ariaLiveRegion = document.getElementById("live-announcer")
+    // ariaLiveRegion.replaceChildren()
+    // const pTag = document.createElement('p')
+    document.getElementById("query_error_message").replaceChildren()
+    document.getElementById("query_error_message").textContent = "HELLO WORLD"
+    // pTag.textContent ="HELLO WORLD"
+    // console.log("DROO", ariaLiveRegion)
+    // console.log("DROO", pTag)
+
+    // ariaLiveRegion.appendChild(pTag)
+    this.errorMessageTarget.classList.remove("display-none")
+    this.queryInputTarget.classList.add("usa-input--error")
+    this.queryInputTarget.setAttribute("aria-invalid", "true")
+    this.toggleErrorIds(this.queryInputTarget, true)
+    this.searchFormTarget.classList.remove("margin-bottom-4")
+  }
+
+  hideError() {
+    document.getElementById("query_error_message").replaceChildren()
+    document.getElementById("query_error_message").textContent = "GOODBYE WORLD"
+    // const ariaLiveRegion = document.getElementById("live-announcer")
+    // ariaLiveRegion.replaceChildren()
+    // const pTag = document.createElement('p')
+    // pTag.textContent ="GOODBYE WORLD"
+    // console.log("DROO", ariaLiveRegion)
+    // console.log("DROO", pTag)
+
+    // ariaLiveRegion.appendChild(pTag)
+    this.errorMessageTarget.classList.add("display-none")
+    this.queryInputTarget.classList.remove("usa-input--error")
+    this.queryInputTarget.removeAttribute("aria-invalid")
+    this.toggleErrorIds(this.queryInputTarget, false)
+    this.searchFormTarget.classList.add("margin-bottom-4")
   }
 
   onSuccess(accountId) {

--- a/app/app/javascript/utilities/accessibility.js
+++ b/app/app/javascript/utilities/accessibility.js
@@ -12,6 +12,8 @@ export function toggleErrorIds(target, error, id) {
   target.setAttribute("aria-describedby", describeIds)
 }
 
+// TODO: Add a guard around race conditions in case multiple components are calling this function
+// --> potential for first one not to be read out by SR if it gets replaced too quickly
 export function updateAriaLiveRegion(text) {
   const liveRegion = document.getElementById("live-announcer")
   liveRegion.replaceChildren()

--- a/app/app/javascript/utilities/accessibility.js
+++ b/app/app/javascript/utilities/accessibility.js
@@ -1,0 +1,21 @@
+export function toggleErrorIds(target, error, id) {
+  const describedbyList = target.getAttribute("aria-describedby")
+  if (error && describedbyList.includes(id)) return
+  let describeIds
+
+  if (error) {
+    describeIds = id + " " + describedbyList
+  } else {
+    describeIds = describedbyList.replace(id, "").trim()
+  }
+
+  target.setAttribute("aria-describedby", describeIds)
+}
+
+export function updateAriaLiveRegion(text) {
+  const liveRegion = document.getElementById("live-announcer")
+  liveRegion.replaceChildren()
+  if (text) {
+    liveRegion.textContent = text
+  }
+}

--- a/app/app/views/cbv/employer_searches/_employer.html.erb
+++ b/app/app/views/cbv/employer_searches/_employer.html.erb
@@ -3,14 +3,11 @@
     <%= render partial: "unemployment_search_tips" %>
   <% end %>
 
-  <div role="region" aria-live="polite" />
-    <% if @query.present? %>
-  
-      <h2 class="site-preview-heading margin-bottom-2">
-        <%= t("cbv.employer_searches.show.results") %> (<%= @employers.count %>)
-      </h2>
-    <% end %>
-  </div>
+  <% if @query.present? %>
+    <h2 class="site-preview-heading margin-bottom-2">
+      <%= t("cbv.employer_searches.show.results") %> (<%= @employers.count %>)
+    </h2>
+  <% end %>
   <div class="usa-card-group">
     <% @employers.each do |employer| %>
       <div class="usa-card usa-card--flag usa-card--media-right desktop:grid-col-6">

--- a/app/app/views/cbv/employer_searches/_employer.html.erb
+++ b/app/app/views/cbv/employer_searches/_employer.html.erb
@@ -3,11 +3,14 @@
     <%= render partial: "unemployment_search_tips" %>
   <% end %>
 
-  <% if @query.present? %>
-    <h2 class="site-preview-heading margin-bottom-2">
-      <%= t("cbv.employer_searches.show.results") %> (<%= @employers.count %>)
-    </h2>
-  <% end %>
+  <div role="region" aria-live="polite" />
+    <% if @query.present? %>
+  
+      <h2 class="site-preview-heading margin-bottom-2">
+        <%= t("cbv.employer_searches.show.results") %> (<%= @employers.count %>)
+      </h2>
+    <% end %>
+  </div>
   <div class="usa-card-group">
     <% @employers.each do |employer| %>
       <div class="usa-card usa-card--flag usa-card--media-right desktop:grid-col-6">

--- a/app/app/views/cbv/employer_searches/show.html.erb
+++ b/app/app/views/cbv/employer_searches/show.html.erb
@@ -27,10 +27,10 @@
 
   <div id="company_examples" class="text-gray-50"><%= t(".company_examples") %></div>
 
-  <%= form_with url: cbv_flow_employer_search_path, method: :get, class: "usa-search usa-search--big margin-bottom-4 margin-top-2", html: { role: "search" }, data: { turbo_frame: "employers", turbo_action: "advance", action: "reset->cbv-employer-search#onSearchReset" } do |f| %>
+  <%= form_with url: cbv_flow_employer_search_path, method: :get, class: "usa-search usa-search--big margin-bottom-4 margin-top-2", html: { role: "search" }, data: { turbo_frame: "employers", turbo_action: "advance", action: "reset->cbv-employer-search#onSearchReset submit->cbv-employer-search#onSubmit", "cbv-employer-search-target": "searchForm" } do |f| %>
     <div class="cbv-employer-search__input-wrapper">
       <%= f.text_field :query, value: @query, class: "usa-input", type: "search",
-            aria: { describedby: "company_examples" },
+            aria: { describedby: "company_examples"  },
             data: { "cbv-employer-search-target": "queryInput", action: "input->cbv-employer-search#toggleClearButton" } %>
       <button
         type="reset"
@@ -52,6 +52,13 @@
         <%= image_tag "@uswds/uswds/dist/img/usa-icons-bg/search--white.svg", class: "usa-search__submit-icon", alt: "Search" %>
     </button>
   <% end %>
+
+  <p
+    id="query_error_message"
+    class="usa-error-message margin-top-0 display-none"
+    data-cbv-employer-search-target="errorMessage"
+    role="status"
+  ><%= t(".blank_query_error") %></p>
 
   <%= render partial: "employer", locals: { employer: @employers } %>
 

--- a/app/app/views/cbv/employer_searches/show.html.erb
+++ b/app/app/views/cbv/employer_searches/show.html.erb
@@ -57,7 +57,6 @@
     id="query_error_message"
     class="usa-error-message margin-top-0 display-none"
     data-cbv-employer-search-target="errorMessage"
-    role="status"
   ><%= t(".blank_query_error") %></p>
 
   <%= render partial: "employer", locals: { employer: @employers } %>

--- a/app/app/views/layouts/application.html.erb
+++ b/app/app/views/layouts/application.html.erb
@@ -13,6 +13,8 @@
   </head>
 
   <body>
+    <div id="live-announcer" role="region" aria-live="polite" aria-atomic="true" class="usa-sr-only">
+    </div>
     <div id="root">
       <a class="usa-skipnav" href="#main-content"><%= t("shared.skip_link") %></a>
       <%= render "application/header" %>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -265,6 +265,7 @@ en:
           heading: Need help connecting to your payroll provider?
           help_options: Get help here.
         app_based_providers: App-based employers
+        blank_query_error: Enter letters or numbers
         can_not_find_employer: Explore your options
         clear_search: Clear search
         company_examples: 'Examples: Uber, McDonald''s, ADP'

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -167,6 +167,7 @@ es:
           heading: "¿Necesita ayuda para conectarse a su proveedor de nómina?"
           help_options: Obtenga ayuda aquí.
         app_based_providers: Empleadores basados
+        blank_query_error: Escriba letras o números
         can_not_find_employer: Explore sus opciones
         clear_search: Borrar búsqueda
         company_examples: 'Ejemplos: Uber, McDonald''s, ADP'

--- a/app/spec/javascript/controllers/employer_search.spec.js
+++ b/app/spec/javascript/controllers/employer_search.spec.js
@@ -254,6 +254,97 @@ describe("EmployerSearchController clear button", () => {
   })
 })
 
+describe("EmployerSearchController blank query error", () => {
+  let controllerElement
+  let form
+  let queryInput
+  let errorMessage
+
+  beforeEach(async () => {
+    controllerElement = document.createElement("div")
+    controllerElement.setAttribute("data-controller", "cbv-employer-search")
+
+    form = document.createElement("form")
+    form.setAttribute("data-action", "submit->cbv-employer-search#onSubmit")
+    form.setAttribute("data-cbv-employer-search-target", "searchForm")
+    form.classList.add("margin-bottom-4")
+
+    queryInput = document.createElement("input")
+    queryInput.setAttribute("type", "search")
+    queryInput.setAttribute("data-cbv-employer-search-target", "queryInput")
+    queryInput.setAttribute("data-action", "input->cbv-employer-search#toggleClearButton")
+
+    const clearButton = document.createElement("button")
+    clearButton.setAttribute("type", "reset")
+    clearButton.setAttribute("data-cbv-employer-search-target", "clearButton")
+    clearButton.hidden = true
+
+    errorMessage = document.createElement("p")
+    errorMessage.setAttribute("data-cbv-employer-search-target", "errorMessage")
+    errorMessage.classList.add("display-none")
+
+    form.appendChild(queryInput)
+    form.appendChild(clearButton)
+    form.appendChild(errorMessage)
+    controllerElement.appendChild(form)
+    document.body.appendChild(controllerElement)
+
+    await window.Stimulus.register("cbv-employer-search", EmployerSearchController)
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  it("shows the error and prevents submission when the query is blank", () => {
+    const event = new Event("submit", { bubbles: true, cancelable: true })
+    form.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(errorMessage.classList.contains("display-none")).toBe(false)
+    expect(queryInput.classList.contains("usa-input--error")).toBe(true)
+    expect(queryInput.getAttribute("aria-invalid")).toBe("true")
+    expect(form.classList.contains("margin-bottom-1")).toBe(true)
+    expect(form.classList.contains("margin-bottom-4")).toBe(false)
+  })
+
+  it("shows the error and prevents submission when the query is only whitespace", () => {
+    queryInput.value = "   "
+
+    const event = new Event("submit", { bubbles: true, cancelable: true })
+    form.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(errorMessage.classList.contains("display-none")).toBe(false)
+  })
+
+  it("does not show an error and allows submission when the query is present", () => {
+    queryInput.value = "Walmart"
+
+    const event = new Event("submit", { bubbles: true, cancelable: true })
+    form.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(errorMessage.classList.contains("display-none")).toBe(true)
+    expect(queryInput.classList.contains("usa-input--error")).toBe(false)
+    expect(queryInput.getAttribute("aria-invalid")).toBeNull()
+  })
+
+  it("hides the error as soon as the user types a character", () => {
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }))
+    expect(errorMessage.classList.contains("display-none")).toBe(false)
+
+    queryInput.value = "W"
+    queryInput.dispatchEvent(new Event("input", { bubbles: true }))
+
+    expect(errorMessage.classList.contains("display-none")).toBe(true)
+    expect(queryInput.classList.contains("usa-input--error")).toBe(false)
+    expect(queryInput.getAttribute("aria-invalid")).toBeNull()
+    expect(form.classList.contains("margin-bottom-4")).toBe(true)
+    expect(form.classList.contains("margin-bottom-1")).toBe(false)
+  })
+})
+
 describe("EmployerSearchController multiple instances on same page!", () => {
   let stimulusElement1
   let stimulusElement2

--- a/app/spec/javascript/controllers/employer_search.spec.js
+++ b/app/spec/javascript/controllers/employer_search.spec.js
@@ -259,6 +259,7 @@ describe("EmployerSearchController blank query error", () => {
   let form
   let queryInput
   let errorMessage
+  let liveAnnouncer
 
   beforeEach(async () => {
     controllerElement = document.createElement("div")
@@ -273,6 +274,7 @@ describe("EmployerSearchController blank query error", () => {
     queryInput.setAttribute("type", "search")
     queryInput.setAttribute("data-cbv-employer-search-target", "queryInput")
     queryInput.setAttribute("data-action", "input->cbv-employer-search#toggleClearButton")
+    queryInput.setAttribute("aria-describedby", "company_examples")
 
     const clearButton = document.createElement("button")
     clearButton.setAttribute("type", "reset")
@@ -282,12 +284,19 @@ describe("EmployerSearchController blank query error", () => {
     errorMessage = document.createElement("p")
     errorMessage.setAttribute("data-cbv-employer-search-target", "errorMessage")
     errorMessage.classList.add("display-none")
+    errorMessage.textContent = "Enter letters or numbers"
 
     form.appendChild(queryInput)
     form.appendChild(clearButton)
     form.appendChild(errorMessage)
     controllerElement.appendChild(form)
     document.body.appendChild(controllerElement)
+
+    // Rendered by the app layout in production; the controller reaches for
+    // it by id, so it must exist in the DOM independent of this controller.
+    liveAnnouncer = document.createElement("div")
+    liveAnnouncer.id = "live-announcer"
+    document.body.appendChild(liveAnnouncer)
 
     await window.Stimulus.register("cbv-employer-search", EmployerSearchController)
   })
@@ -296,7 +305,7 @@ describe("EmployerSearchController blank query error", () => {
     document.body.innerHTML = ""
   })
 
-  it("shows the error and prevents submission when the query is blank", () => {
+  it("shows the error, prevents submission, and announces it when the query is blank", () => {
     const event = new Event("submit", { bubbles: true, cancelable: true })
     form.dispatchEvent(event)
 
@@ -304,8 +313,9 @@ describe("EmployerSearchController blank query error", () => {
     expect(errorMessage.classList.contains("display-none")).toBe(false)
     expect(queryInput.classList.contains("usa-input--error")).toBe(true)
     expect(queryInput.getAttribute("aria-invalid")).toBe("true")
-    expect(form.classList.contains("margin-bottom-1")).toBe(true)
+    expect(queryInput.getAttribute("aria-describedby")).toBe("query_error_message company_examples")
     expect(form.classList.contains("margin-bottom-4")).toBe(false)
+    expect(liveAnnouncer.textContent).toBe("Enter letters or numbers")
   })
 
   it("shows the error and prevents submission when the query is only whitespace", () => {
@@ -328,9 +338,10 @@ describe("EmployerSearchController blank query error", () => {
     expect(errorMessage.classList.contains("display-none")).toBe(true)
     expect(queryInput.classList.contains("usa-input--error")).toBe(false)
     expect(queryInput.getAttribute("aria-invalid")).toBeNull()
+    expect(queryInput.getAttribute("aria-describedby")).toBe("company_examples")
   })
 
-  it("hides the error as soon as the user types a character", () => {
+  it("hides the error, clears the announcement, and restores spacing as soon as the user types a character", () => {
     form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }))
     expect(errorMessage.classList.contains("display-none")).toBe(false)
 
@@ -340,8 +351,16 @@ describe("EmployerSearchController blank query error", () => {
     expect(errorMessage.classList.contains("display-none")).toBe(true)
     expect(queryInput.classList.contains("usa-input--error")).toBe(false)
     expect(queryInput.getAttribute("aria-invalid")).toBeNull()
+    expect(queryInput.getAttribute("aria-describedby")).toBe("company_examples")
     expect(form.classList.contains("margin-bottom-4")).toBe(true)
-    expect(form.classList.contains("margin-bottom-1")).toBe(false)
+    expect(liveAnnouncer.textContent).toBe("")
+  })
+
+  it("does not duplicate the error id in aria-describedby when submitted blank twice in a row", () => {
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }))
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }))
+
+    expect(queryInput.getAttribute("aria-describedby")).toBe("query_error_message company_examples")
   })
 })
 

--- a/app/spec/javascript/utilities/accessibility.spec.js
+++ b/app/spec/javascript/utilities/accessibility.spec.js
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { toggleErrorIds, updateAriaLiveRegion } from "@js/utilities/accessibility"
+
+describe("toggleErrorIds", () => {
+  let target
+
+  afterEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  it("adds the id to aria-describedby when there's an error and it isn't already present", () => {
+    target = document.createElement("input")
+    target.setAttribute("aria-describedby", "company_examples")
+
+    toggleErrorIds(target, true, "query_error_message")
+
+    expect(target.getAttribute("aria-describedby")).toBe("query_error_message company_examples")
+  })
+
+  it("does not duplicate the id when called again while the error is already present", () => {
+    target = document.createElement("input")
+    target.setAttribute("aria-describedby", "company_examples")
+
+    toggleErrorIds(target, true, "query_error_message")
+    toggleErrorIds(target, true, "query_error_message")
+
+    expect(target.getAttribute("aria-describedby")).toBe("query_error_message company_examples")
+  })
+
+  it("removes the id and trims whitespace when the error is cleared", () => {
+    target = document.createElement("input")
+    target.setAttribute("aria-describedby", "query_error_message company_examples")
+
+    toggleErrorIds(target, false, "query_error_message")
+
+    expect(target.getAttribute("aria-describedby")).toBe("company_examples")
+  })
+})
+
+describe("updateAriaLiveRegion", () => {
+  let liveRegion
+
+  beforeEach(() => {
+    liveRegion = document.createElement("div")
+    liveRegion.id = "live-announcer"
+    document.body.appendChild(liveRegion)
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  it("sets the live region's text content", () => {
+    updateAriaLiveRegion("Enter letters or numbers")
+
+    expect(liveRegion.textContent).toBe("Enter letters or numbers")
+  })
+
+  it("clears prior content when called with no text", () => {
+    updateAriaLiveRegion("Enter letters or numbers")
+    updateAriaLiveRegion()
+
+    expect(liveRegion.textContent).toBe("")
+  })
+})


### PR DESCRIPTION
## Summary
Adds accessible client-side validation for blank submissions on the "Find your employer or payroll company" search step. Previously, submitting an empty search reloaded the page with no feedback to the user, sighted or otherwise.

## Type of Change
Check all that apply.
- [x] Bug
- [ ] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
- Blank search submissions are now caught client-side (`onSubmit` in `employer_search.js`) and prevented from submitting; a visible error message is shown and the input is marked `aria-invalid` with an `aria-describedby` association.
- Added an app-wide `#live-announcer` `aria-live="polite"` region to `application.html.erb` so the error is announced to screen reader users when it appears (and cleared when it's dismissed).
- Extracted the `aria-describedby` list management (`toggleErrorIds`) and live-region announcement (`updateAriaLiveRegion`) into a new shared utility, `app/javascript/utilities/accessibility.js`, so the pattern can be reused by other forms.
- Added `cbv.employer_searches.show.blank_query_error` translation key (English and Spanish) for the error copy.
- Added the static, `display-none`-toggled error `<p>` element and `searchForm` Stimulus target in `show.html.erb`.

## Checklist
- [x] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
- Validation is intentionally pure client-side (no server round-trip) 
- `toggleErrorIds`/`updateAriaLiveRegion` live in `app/javascript/utilities/accessibility.js` with direct unit tests in `spec/javascript/utilities/accessibility.spec.js`; `employer_search.spec.js` needed no behavioral changes since the controller's external behavior is unchanged.

https://github.com/user-attachments/assets/0022bb5f-8e8e-458f-b348-9bf45f06b5cd

