### PR TITLE
PF-740: Character counter additional comments

### DIFF
--- a/app/app/controllers/cbv/payment_details_controller.rb
+++ b/app/app/controllers/cbv/payment_details_controller.rb
@@ -119,7 +119,7 @@ class Cbv::PaymentDetailsController < Cbv::BaseController
   end
 
   def sanitize_comment(comment)
-    ActionController::Base.helpers.sanitize(comment)
+    ActionController::Base.helpers.sanitize(comment).to_s.first(1000)
   end
 
   def track_viewed_event

--- a/app/app/javascript/controllers/cbv/character_count_controller.js
+++ b/app/app/javascript/controllers/cbv/character_count_controller.js
@@ -1,0 +1,66 @@
+import { Controller } from "@hotwired/stimulus"
+
+const ERROR_CLASS = "usa-error-message"
+const HINT_CLASS = "usa-hint"
+
+export default class extends Controller {
+  static targets = ["input", "message", "srMessage", "submitButton"]
+  static values = {
+    maxlength: Number,
+    overLimitText: String,
+    shortenText: String,
+  }
+
+  connect() {
+    this.update()
+  }
+
+  guardSubmit(event) {
+    if (this.submitButtonTarget.getAttribute("aria-disabled") === "true") {
+      event.preventDefault()
+    }
+  }
+
+  update() {
+    const length = this.inputTarget.value.length
+    const over = length - this.maxlengthValue
+
+    if (over > 0) {
+      this.showError(over)
+    } else {
+      this.showCount(length)
+    }
+  }
+
+  showCount(length) {
+    this.messageTarget.textContent = `${length}/${this.maxlengthValue} characters remaining`
+    this.messageTarget.classList.remove(ERROR_CLASS)
+    this.messageTarget.classList.add(HINT_CLASS)
+    this.srMessageTarget.textContent = ""
+
+    this.inputTarget.classList.remove("usa-input--error")
+    this.inputTarget.removeAttribute("aria-invalid")
+    this.enableSubmit()
+  }
+
+  showError(over) {
+    const message = `${this.overLimitTextValue.replace("{count}", over)} ${this.shortenTextValue}`
+
+    this.messageTarget.textContent = message
+    this.messageTarget.classList.remove(HINT_CLASS)
+    this.messageTarget.classList.add(ERROR_CLASS)
+    this.srMessageTarget.textContent = message
+
+    this.inputTarget.classList.add("usa-input--error")
+    this.inputTarget.setAttribute("aria-invalid", "true")
+    this.disableSubmit()
+  }
+
+  enableSubmit() {
+    this.submitButtonTarget.setAttribute("aria-disabled", "false")
+  }
+
+  disableSubmit() {
+    this.submitButtonTarget.setAttribute("aria-disabled", "true")
+  }
+}

--- a/app/app/javascript/controllers/cbv/character_count_controller.js
+++ b/app/app/javascript/controllers/cbv/character_count_controller.js
@@ -33,7 +33,7 @@ export default class extends Controller {
   }
 
   showCount(length) {
-    this.messageTarget.textContent = `${length}/${this.maxlengthValue} characters remaining`
+    this.messageTarget.textContent = `${length}/${this.maxlengthValue}`
     this.messageTarget.classList.remove(ERROR_CLASS)
     this.messageTarget.classList.add(HINT_CLASS)
     this.srMessageTarget.textContent = ""

--- a/app/app/javascript/controllers/index.js
+++ b/app/app/javascript/controllers/index.js
@@ -15,6 +15,7 @@ import PreviewFormController from "./preview_form_controller.js"
 import PreviewToggleController from "./preview_toggle_controller.js"
 import ClickTrackerController from "./click_tracker_controller.js"
 import AttestationCheckController from "./cbv/attestation_check_controller.js"
+import CharacterCountController from "./cbv/character_count_controller.js"
 import TooltipTrackerController from "./employer_search_tooltip_tracker_controller.js"
 import AccordionController from "./accordion_controller.js"
 import UnemployedTipsController from "./unemployed_tips_controller.js"
@@ -35,6 +36,7 @@ application.register("preview-form", PreviewFormController)
 application.register("preview-toggle", PreviewToggleController)
 application.register("session-timeout", SessionTimeoutPageController)
 application.register("cbv-attestation-check", AttestationCheckController)
+application.register("cbv-character-count", CharacterCountController)
 application.register("tooltip-tracker", TooltipTrackerController)
 application.register("accordion", AccordionController)
 application.register("unemployed-tips", UnemployedTipsController)

--- a/app/app/views/cbv/payment_details/show.html.erb
+++ b/app/app/views/cbv/payment_details/show.html.erb
@@ -58,7 +58,7 @@
     <%= hidden_field_tag "user[account_id]", params[:user][:account_id] %>
     <%= form.label :additional_information, t(".additional_information_label", agency_acronym: agency_acronym_or_full_name), class: "usa-label", id: "additional_information_description" %>
     <%= form.text_area :additional_information, class: "usa-textarea", rows: 5, value: @account_comment, placeholder: t(".additional_information_placeholder"), "aria-labelledby": "additional_info_header additional_information_description", "aria-describedby": "additional_information_count", data: { cbv_character_count_target: "input", action: "input->cbv-character-count#update" } %>
-    <%= content_tag :div, "0/1000 characters remaining", id: "additional_information_count", class: "usa-hint margin-top-1", data: { cbv_character_count_target: "message" } %>
+    <%= content_tag :div, "0/1000", id: "additional_information_count", class: "usa-hint margin-top-1", data: { cbv_character_count_target: "message" } %>
     <%= content_tag :div, "", class: "usa-sr-only", "aria-live": "polite", data: { cbv_character_count_target: "srMessage" } %>
     <%= form.submit t(".continue"), class: "usa-button usa-button--primary", data: { cbv_character_count_target: "submitButton" } %>
   <% end %>

--- a/app/app/views/cbv/payment_details/show.html.erb
+++ b/app/app/views/cbv/payment_details/show.html.erb
@@ -48,12 +48,18 @@
 <% else %>
   <%= render(Report::GigMonthlySummaryTableComponent.new(@aggregator_report, @payroll_account)) %>
 <% end %>
-<div class="usa-form-group margin-top-5">
-  <h2><%= t(".additional_information_header") %></h2>
-  <%= form_with(model: @cbv_flow, url: cbv_flow_payment_details_path, method: :patch, class: "usa-form usa-form--large") do |form| %>
+<div class="usa-form-group margin-top-5"
+     data-controller="cbv-character-count"
+     data-cbv-character-count-maxlength-value="1000"
+     data-cbv-character-count-over-limit-text-value="<%= t(".character_count_over_limit") %>"
+     data-cbv-character-count-shorten-text-value="<%= t(".character_count_shorten") %>">
+  <h2 id="additional_info_header"><%= t(".additional_information_header") %></h2>
+  <%= form_with(model: @cbv_flow, url: cbv_flow_payment_details_path, method: :patch, class: "usa-form usa-form--large", data: { action: "submit->cbv-character-count#guardSubmit" }) do |form| %>
     <%= hidden_field_tag "user[account_id]", params[:user][:account_id] %>
-    <%= form.label :additional_information, t(".additional_information_label", agency_acronym: agency_acronym_or_full_name), class: "usa-label" %>
-    <%= form.text_area :additional_information, class: "usa-textarea", rows: 5, value: @account_comment, maxlength: 1000, placeholder: t(".additional_information_placeholder") %>
-    <%= form.submit t(".continue"), class: "usa-button usa-button--primary" %>
+    <%= form.label :additional_information, t(".additional_information_label", agency_acronym: agency_acronym_or_full_name), class: "usa-label", id: "additional_information_description" %>
+    <%= form.text_area :additional_information, class: "usa-textarea", rows: 5, value: @account_comment, placeholder: t(".additional_information_placeholder"), "aria-labelledby": "additional_info_header additional_information_description", "aria-describedby": "additional_information_count", data: { cbv_character_count_target: "input", action: "input->cbv-character-count#update" } %>
+    <%= content_tag :div, "0/1000 characters remaining", id: "additional_information_count", class: "usa-hint margin-top-1", data: { cbv_character_count_target: "message" } %>
+    <%= content_tag :div, "", class: "usa-sr-only", "aria-live": "polite", data: { cbv_character_count_target: "srMessage" } %>
+    <%= form.submit t(".continue"), class: "usa-button usa-button--primary", data: { cbv_character_count_target: "submitButton" } %>
   <% end %>
 </div>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -399,6 +399,8 @@ en:
         additional_information_header: Additional comments (Optional)
         additional_information_label: Share any comments or additional information about the income details above that you’d like %{agency_acronym} to know. For example, you can share if the information is inaccurate or if you’re no longer working at that job.
         additional_information_placeholder: Enter up to 1000 characters
+        character_count_over_limit: "{count} characters over limit."
+        character_count_shorten: Please make your comment shorter.
         continue: Continue
         deductions: 'Deduction: %{category} (%{tax})'
         deposit_accounts:

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -301,6 +301,8 @@ es:
         additional_information_header: Comentarios adicionales (Opcional)
         additional_information_label: Comparta cualquier comentario o información adicional sobre los detalles de pago anteriores que desea que %{agency_acronym} conozca. Por ejemplo, puede compartir si la información es inexacta o si ya no trabaja en ese empleo.
         additional_information_placeholder: Introduzca hasta 1000 caracteres
+        character_count_over_limit: Hay {count} caracteres de más.
+        character_count_shorten: Acorte el comentario, por favor.
         continue: Continuar
         deductions: 'Deducción: %{category} (%{tax})'
         deposit_accounts:

--- a/app/spec/javascript/controllers/cbv/character_count_controller.spec.js
+++ b/app/spec/javascript/controllers/cbv/character_count_controller.spec.js
@@ -70,7 +70,7 @@ describe("CharacterCountController", () => {
   })
 
   it("shows an initial count, enables the submit button, and keeps it focusable", () => {
-    expect(message.textContent).toBe("0/1000 characters remaining")
+    expect(message.textContent).toBe("0/1000")
     expect(srMessage.textContent).toBe("")
     expect(submitButton.disabled).toBe(false)
     expect(submitButton.getAttribute("aria-disabled")).toBe("false")
@@ -84,7 +84,7 @@ describe("CharacterCountController", () => {
     })
 
     it("updates the visible counter without announcing anything, and allows submission", () => {
-      expect(message.textContent).toBe("500/1000 characters remaining")
+      expect(message.textContent).toBe("500/1000")
       expect(srMessage.textContent).toBe("")
       expect(input.hasAttribute("aria-invalid")).toBe(false)
       expect(submitButton.disabled).toBe(false)
@@ -123,7 +123,7 @@ describe("CharacterCountController", () => {
       })
 
       it("clears the error state, re-enables the submit button, and allows submission", () => {
-        expect(message.textContent).toBe("200/1000 characters remaining")
+        expect(message.textContent).toBe("200/1000")
         expect(srMessage.textContent).toBe("")
         expect(input.hasAttribute("aria-invalid")).toBe(false)
         expect(submitButton.disabled).toBe(false)

--- a/app/spec/javascript/controllers/cbv/character_count_controller.spec.js
+++ b/app/spec/javascript/controllers/cbv/character_count_controller.spec.js
@@ -1,0 +1,136 @@
+import { describe, beforeEach, afterEach, it, expect, vi } from "vitest"
+import { Application } from "@hotwired/stimulus"
+import CharacterCountController from "@js/controllers/cbv/character_count_controller"
+
+describe("CharacterCountController", () => {
+  let application
+  let container
+  let form
+  let input
+  let message
+  let srMessage
+  let submitButton
+
+  const setValue = (value) => {
+    input.value = value
+    input.dispatchEvent(new Event("input"))
+  }
+
+  const dispatchSubmit = () => {
+    const event = new Event("submit", { bubbles: true, cancelable: true })
+    form.dispatchEvent(event)
+    return event
+  }
+
+  beforeEach(() => {
+    container = document.createElement("div")
+    container.setAttribute("data-controller", "character-count")
+    container.setAttribute("data-character-count-maxlength-value", "1000")
+    container.setAttribute(
+      "data-character-count-over-limit-text-value",
+      "{count} characters over limit."
+    )
+    container.setAttribute(
+      "data-character-count-shorten-text-value",
+      "Please make your comment shorter."
+    )
+
+    form = document.createElement("form")
+    form.setAttribute("data-action", "submit->character-count#guardSubmit")
+
+    input = document.createElement("textarea")
+    input.setAttribute("data-character-count-target", "input")
+    input.setAttribute("data-action", "input->character-count#update")
+
+    message = document.createElement("div")
+    message.setAttribute("data-character-count-target", "message")
+
+    srMessage = document.createElement("div")
+    srMessage.setAttribute("data-character-count-target", "srMessage")
+
+    submitButton = document.createElement("input")
+    submitButton.type = "submit"
+    submitButton.setAttribute("data-character-count-target", "submitButton")
+
+    form.appendChild(input)
+    form.appendChild(message)
+    form.appendChild(srMessage)
+    form.appendChild(submitButton)
+    container.appendChild(form)
+    document.body.appendChild(container)
+
+    application = Application.start()
+    application.register("character-count", CharacterCountController)
+  })
+
+  afterEach(() => {
+    application.stop()
+    document.body.innerHTML = ""
+    vi.restoreAllMocks()
+  })
+
+  it("shows an initial count, enables the submit button, and keeps it focusable", () => {
+    expect(message.textContent).toBe("0/1000 characters remaining")
+    expect(srMessage.textContent).toBe("")
+    expect(submitButton.disabled).toBe(false)
+    expect(submitButton.getAttribute("aria-disabled")).toBe("false")
+
+    expect(dispatchSubmit().defaultPrevented).toBe(false)
+  })
+
+  describe("when typing under the limit", () => {
+    beforeEach(() => {
+      setValue("a".repeat(500))
+    })
+
+    it("updates the visible counter without announcing anything, and allows submission", () => {
+      expect(message.textContent).toBe("500/1000 characters remaining")
+      expect(srMessage.textContent).toBe("")
+      expect(input.hasAttribute("aria-invalid")).toBe(false)
+      expect(submitButton.disabled).toBe(false)
+      expect(submitButton.getAttribute("aria-disabled")).toBe("false")
+
+      expect(dispatchSubmit().defaultPrevented).toBe(false)
+    })
+  })
+
+  describe("when typing over the limit", () => {
+    beforeEach(() => {
+      setValue("a".repeat(1050))
+    })
+
+    it("shows the combined error message and marks the field invalid", () => {
+      const expected = "50 characters over limit. Please make your comment shorter."
+
+      expect(message.textContent).toBe(expected)
+      expect(srMessage.textContent).toBe(expected)
+      expect(input.getAttribute("aria-invalid")).toBe("true")
+    })
+
+    it("marks the submit button aria-disabled but keeps it focusable (not the native disabled attribute)", () => {
+      expect(submitButton.disabled).toBe(false)
+      expect(submitButton.getAttribute("aria-disabled")).toBe("true")
+      expect(submitButton.tabIndex).not.toBe(-1)
+    })
+
+    it("blocks form submission", () => {
+      expect(dispatchSubmit().defaultPrevented).toBe(true)
+    })
+
+    describe("and then typing back under the limit", () => {
+      beforeEach(() => {
+        setValue("a".repeat(200))
+      })
+
+      it("clears the error state, re-enables the submit button, and allows submission", () => {
+        expect(message.textContent).toBe("200/1000 characters remaining")
+        expect(srMessage.textContent).toBe("")
+        expect(input.hasAttribute("aria-invalid")).toBe(false)
+        expect(submitButton.disabled).toBe(false)
+        expect(submitButton.getAttribute("aria-disabled")).toBe("false")
+
+        expect(dispatchSubmit().defaultPrevented).toBe(false)
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Adds a USWDS-style character counter to the "Additional comments" field on the payment details ("Review your payment information") page, with an accessible over-limit error state that blocks submission without removing the Continue button from the tab order.

## Type of Change
Check all that apply.
- [ ] Bug
- [x] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
- Added a `cbv-character-count` Stimulus controller that shows a live `X/1000 characters remaining` counter on the additional comments textarea
- Removed the native `maxlength` attribute so users can type past the limit and see the counter switch to a combined error message (e.g. "50 characters over limit. Please make your comment shorter.")
- Screen reader announcements only fire when entering/while in the over-limit state (not on every keystroke), via a dedicated `aria-live` region separate from the always-visible counter
- Continue button uses `aria-disabled` (not the native `disabled` attribute) while over the limit, so it stays focusable/tabbable; actual submission is blocked via a `submit` event guard on the form
- Added `aria-invalid`, `aria-describedby`, and `aria-labelledby` associations between the field, its label, and the counter/error text
- Added English/Spanish translations for the over-limit and "please shorten" messages
- Added a server-side truncation backstop (1000 chars) in `Cbv::PaymentDetailsController#sanitize_comment` as a defensive guard now that the native `maxlength` is removed

## Checklist
- [x] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
<img width="662" height="545" alt="Screenshot 2026-07-18 at 15-15-37 Preview – Review your payment information from Lyft Driver Verify My Income" src="https://github.com/user-attachments/assets/ba7d3f25-a85b-4bcb-8ee3-ad19a9407dc3" />

<img width="696" height="587" alt="Screenshot 2026-07-18 at 15-15-20 Preview – Review your payment information from Lyft Driver Verify My Income" src="https://github.com/user-attachments/assets/ca6201a1-265d-4170-b812-4fd91ed52b4d" />
