### PR TITLE
PF-768: Employer search results announcement

### DIFF
--- a/app/app/javascript/controllers/cbv/employer_search.js
+++ b/app/app/javascript/controllers/cbv/employer_search.js
@@ -13,6 +13,7 @@ export default class extends Controller {
     "clearButton",
     "errorMessage",
     "searchForm",
+    "resultsHeading",
   ]
 
   static values = {
@@ -24,13 +25,24 @@ export default class extends Controller {
   }
 
   async connect() {
+    this.onFrameLoad = this.onFrameLoad.bind(this)
     this.element.addEventListener("turbo:frame-missing", this.onTurboError)
     this.element.addEventListener("turbo:submit-start", this.onSearchStart)
+    this.element.addEventListener("turbo:frame-load", this.onFrameLoad)
   }
 
   disconnect() {
     this.element.removeEventListener("turbo:frame-missing", this.onTurboError)
     this.element.removeEventListener("turbo:submit-start", this.onSearchStart)
+    this.element.removeEventListener("turbo:frame-load", this.onFrameLoad)
+  }
+
+  onFrameLoad(event) {
+    if (event.target.id !== "employers") return
+
+    if (this.hasResultsHeadingTarget) {
+      updateAriaLiveRegion(this.resultsHeadingTarget.textContent.trim())
+    }
   }
 
   onTurboError(event) {

--- a/app/app/javascript/controllers/cbv/employer_search.js
+++ b/app/app/javascript/controllers/cbv/employer_search.js
@@ -38,6 +38,7 @@ export default class extends Controller {
   }
 
   onFrameLoad(event) {
+    // Preventing the heading from being announced when the "Popular" tab is selected and the turbo frame is loaded.
     if (event.target.id !== "employers") return
 
     if (this.hasResultsHeadingTarget) {

--- a/app/app/views/cbv/employer_searches/_employer.html.erb
+++ b/app/app/views/cbv/employer_searches/_employer.html.erb
@@ -4,7 +4,7 @@
   <% end %>
 
   <% if @query.present? %>
-    <h2 class="site-preview-heading margin-bottom-2">
+    <h2 class="site-preview-heading margin-bottom-2" data-cbv-employer-search-target="resultsHeading">
       <%= t("cbv.employer_searches.show.results") %> (<%= @employers.count %>)
     </h2>
   <% end %>

--- a/app/spec/controllers/cbv/employer_searches_controller_spec.rb
+++ b/app/spec/controllers/cbv/employer_searches_controller_spec.rb
@@ -95,6 +95,12 @@ RSpec.describe Cbv::EmployerSearchesController do
         expect(response.body).to include("Results")
       end
 
+      it "marks the results heading with the target JS uses to announce it to screen readers" do
+        get :show, params: { query: "unemployed" }
+        expect(response).to be_successful
+        expect(response.body).to include('data-cbv-employer-search-target="resultsHeading"')
+      end
+
       it "tracks ApplicantAccessedUnemployedHelp with search source" do
         allow(MixpanelEventTrackingJob).to receive(:perform_later).with("CbvPageView", anything, anything)
         allow(MixpanelEventTrackingJob).to receive(:perform_later).with("ApplicantSearchedForEmployer", anything, anything)

--- a/app/spec/javascript/controllers/employer_search.spec.js
+++ b/app/spec/javascript/controllers/employer_search.spec.js
@@ -30,8 +30,8 @@ describe("EmployerSearchController", () => {
     document.body.innerHTML = ""
   })
 
-  it("adds turbo:frame-missing and turbo:submit-start listeners on connect()", () => {
-    expect(stimulusElement.addEventListener).toBeCalledTimes(2)
+  it("adds turbo:frame-missing, turbo:submit-start, and turbo:frame-load listeners on connect()", () => {
+    expect(stimulusElement.addEventListener).toBeCalledTimes(3)
     expect(stimulusElement.addEventListener).toHaveBeenCalledWith(
       "turbo:frame-missing",
       expect.any(Function)
@@ -41,14 +41,20 @@ describe("EmployerSearchController", () => {
       "turbo:submit-start",
       expect.any(Function)
     )
+
+    expect(stimulusElement.addEventListener).toHaveBeenCalledWith(
+      "turbo:frame-load",
+      expect.any(Function)
+    )
   })
 
-  it("removes turbo:frame-missing and turbo:submit-start listeners on disconnect()", async () => {
+  it("removes turbo:frame-missing, turbo:submit-start, and turbo:frame-load listeners on disconnect()", async () => {
     await stimulusElement.remove()
-    expect(stimulusElement.removeEventListener).toBeCalledTimes(2)
+    expect(stimulusElement.removeEventListener).toBeCalledTimes(3)
     const removedEvents = stimulusElement.removeEventListener.mock.calls.map((c) => c[0])
     expect(removedEvents).toContain("turbo:frame-missing")
     expect(removedEvents).toContain("turbo:submit-start")
+    expect(removedEvents).toContain("turbo:frame-load")
   })
 })
 
@@ -361,6 +367,67 @@ describe("EmployerSearchController blank query error", () => {
     form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }))
 
     expect(queryInput.getAttribute("aria-describedby")).toBe("query_error_message company_examples")
+  })
+})
+
+describe("EmployerSearchController results accessible announcement", () => {
+  let controllerElement
+  let employersFrame
+  let resultsHeading
+  let liveAnnouncer
+
+  beforeEach(async () => {
+    controllerElement = document.createElement("div")
+    controllerElement.setAttribute("data-controller", "cbv-employer-search")
+
+    employersFrame = document.createElement("turbo-frame")
+    employersFrame.id = "employers"
+
+    resultsHeading = document.createElement("h2")
+    resultsHeading.setAttribute("data-cbv-employer-search-target", "resultsHeading")
+    resultsHeading.textContent = "\n      Results (3)\n    "
+
+    employersFrame.appendChild(resultsHeading)
+    controllerElement.appendChild(employersFrame)
+    document.body.appendChild(controllerElement)
+
+    // Rendered by the app layout in production; the controller reaches for
+    // it by id, so it must exist in the DOM independent of this controller.
+    liveAnnouncer = document.createElement("div")
+    liveAnnouncer.id = "live-announcer"
+    document.body.appendChild(liveAnnouncer)
+
+    await window.Stimulus.register("cbv-employer-search", EmployerSearchController)
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  it("announces the results heading text when the employers frame loads", () => {
+    const event = new CustomEvent("turbo:frame-load", { bubbles: true })
+    employersFrame.dispatchEvent(event)
+
+    expect(liveAnnouncer.textContent).toBe("Results (3)")
+  })
+
+  it("announces again with the same text on a repeat search with an identical count", () => {
+    employersFrame.dispatchEvent(new CustomEvent("turbo:frame-load", { bubbles: true }))
+    liveAnnouncer.textContent = "stale content to prove it gets cleared"
+
+    employersFrame.dispatchEvent(new CustomEvent("turbo:frame-load", { bubbles: true }))
+
+    expect(liveAnnouncer.textContent).toBe("Results (3)")
+  })
+
+  it("ignores turbo:frame-load events from other frames on the page", () => {
+    const popularFrame = document.createElement("turbo-frame")
+    popularFrame.id = "popular"
+    controllerElement.appendChild(popularFrame)
+
+    popularFrame.dispatchEvent(new CustomEvent("turbo:frame-load", { bubbles: true }))
+
+    expect(liveAnnouncer.textContent).toBe("")
   })
 })
 


### PR DESCRIPTION
## Summary
Announces employer search results to screen reader users. Previously, submitting a search on the "Find your employer or payroll company" step re-rendered the "Results (#)" heading and card list via a Turbo Frame swap, but nothing was communicated to assistive technology — screen reader users had to manually explore the page to discover whether results appeared.

## Type of Change
- [ ] Bug
- [x] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
- Added a `resultsHeading` Stimulus target to the results `<h2>` in `_employer.html.erb`
- Added a `turbo:frame-load` listener in `employer_search_controller.js` that, when the `employers` frame reloads, reads the rendered heading text and pushes it into the existing `#live-announcer` region via `updateAriaLiveRegion` (reusing the same helper already used for the blank-query error message)
- Filtered the listener to the `employers` frame specifically, since the same controller element also wraps the `popular` providers frame, which fires its own `turbo:frame-load` events on tab switches
- Added Vitest coverage asserting the live region is updated on frame load, re-announced on a repeat search with an identical result count, and left untouched by unrelated frame loads
- Added an RSpec assertion that the results heading renders with the `data-cbv-employer-search-target="resultsHeading"` attribute the JS depends on

## Checklist
- [x] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
- Comment made in code as well, but would just like to confirm that testing the smaller mocked version is okay or if we would prefer to do an actual integration test for this.


https://github.com/user-attachments/assets/f4c4e577-b670-40a7-82f4-0d278e2638db

(note: the second `Results 10` on the Uber search was because I hit the enter key twice, not a bug!)