### PR TITLE
PF-761: Radio input color contrast

### DIFF
--- a/app/app/assets/stylesheets/uswds-overrides.scss
+++ b/app/app/assets/stylesheets/uswds-overrides.scss
@@ -27,11 +27,13 @@
   max-width: none;
 }
 
-// USWDS tile checkboxes fill the label with a translucent blue background
-// when checked, which drops the focus ring below the 3:1 non-text contrast
-// minimum. Keep the border as the checked-state indicator and drop the fill.
-.usa-checkbox__input--tile {
-  &:checked, {
+// USWDS tile checkboxes and radios fill the label with a translucent blue
+// background when checked, which drops the focus ring below the 3:1 non-text
+// contrast minimum. Keep the border as the checked-state indicator and drop
+// the fill.
+.usa-checkbox__input--tile,
+.usa-radio__input--tile {
+  &:checked {
     + [class*="__label"] {
       background-color: color($theme-body-background-color);
     }


### PR DESCRIPTION
## Summary
Fixes a WCAG contrast failure where the focus ring on selected tile-style radio buttons (and checkboxes) fell below the 3:1 minimum for non-text UI indicators, because USWDS fills the tile with a translucent blue background when checked.

## Type of Change
Check all that apply.
- [x] Bug
- [ ] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
- Extended the existing tile-checkbox background override in `app/app/assets/stylesheets/uswds-overrides.scss` to also cover tile radios (`.usa-checkbox__input--tile, .usa-radio__input--tile`), removing duplication by sharing one rule/comment for both.
- Strips the translucent blue checked-state fill back to `color($theme-body-background-color)` (existing USWDS theme token, no hardcoded hex), leaving the existing blue border as the sole selected-state indicator.
- Affects the "Do you have another job to report" Yes/No radios on `/cbv/add_job` and `/cbv/other_job` (both rendered via `UswdsFormBuilder#radio_button`), plus any other tile-radio usage (e.g. caseworker invitation fields) via the shared selector.

## Checklist
- [ ] Tests added/updated (if needed) — CSS-only change, no automated test added
- [ ] Docs updated (if needed) — N/A

## Notes for Reviewers
- Verify manually: reach `/cbv/add_job` or `/cbv/other_job`, select a Yes/No radio, tab away and back — the tile should show a white background with only the blue border as the selected indicator, and the focus ring should now read 3:1 against it.

### Add job
<img width="855" height="690" alt="Screenshot 2026-07-27 151903" src="https://github.com/user-attachments/assets/8fd82aff-2be1-464f-894a-d7df4264756b" />


### Other job
<img width="1108" height="505" alt="Screenshot 2026-07-27 152240" src="https://github.com/user-attachments/assets/27adc5b4-14b6-4bc9-9072-6171f50eb78f" />
