### PR TITLE
Drew/pf 702 tab structure payroll popular

### DIFF
--- a/app/app/javascript/controllers/cbv/employer_search.js
+++ b/app/app/javascript/controllers/cbv/employer_search.js
@@ -131,7 +131,7 @@ export default class extends Controller {
   onTabKeydown(event) {
     const tabs = this.tabTargets
     // finds which tab just received the keydown from the element listener it is bound to,
-    // i.e. whichever tab is currently focused).
+    // i.e. whichever tab is currently focused.
     const currentIndex = tabs.indexOf(event.currentTarget)
     let newIndex
 

--- a/app/app/javascript/controllers/cbv/employer_search.js
+++ b/app/app/javascript/controllers/cbv/employer_search.js
@@ -51,6 +51,7 @@ export default class extends Controller {
     this.element.removeEventListener("turbo:frame-missing", this.onTurboError)
     this.element.removeEventListener("turbo:submit-start", this.onSearchStart)
     this.element.removeEventListener("turbo:frame-load", this.onFrameLoad)
+    this.element.removeEventListener("turbo:frame-load", this.onPopularFrameLoad)
   }
 
   onFrameLoad(event) {
@@ -60,7 +61,6 @@ export default class extends Controller {
     if (this.hasResultsHeadingTarget) {
       updateAriaLiveRegion(this.resultsHeadingTarget.textContent.trim())
     }
-    this.element.removeEventListener("turbo:frame-load", this.onPopularFrameLoad)
   }
 
   onTurboError(event) {

--- a/app/app/javascript/controllers/cbv/employer_search.js
+++ b/app/app/javascript/controllers/cbv/employer_search.js
@@ -14,10 +14,25 @@ export default class extends Controller {
     "errorMessage",
     "searchForm",
     "resultsHeading",
+    "tab",
   ]
 
   static values = {
     cbvFlowId: Number,
+  }
+
+  // Turbo replaces the popular-providers frame's contents on every tab
+  // activation, which drops focus. Recorded here (by id, since the tab
+  // elements themselves get destroyed and recreated) so it can be restored
+  // once the frame finishes reloading — see onTabClick/onPopularFrameLoad.
+  pendingTabFocusId = null
+
+  onPopularFrameLoad = (event) => {
+    if (event.target.id !== "popular" || !this.pendingTabFocusId) return
+
+    const tabToFocus = document.getElementById(this.pendingTabFocusId)
+    this.pendingTabFocusId = null
+    tabToFocus?.focus()
   }
 
   async initialize() {
@@ -29,6 +44,7 @@ export default class extends Controller {
     this.element.addEventListener("turbo:frame-missing", this.onTurboError)
     this.element.addEventListener("turbo:submit-start", this.onSearchStart)
     this.element.addEventListener("turbo:frame-load", this.onFrameLoad)
+    this.element.addEventListener("turbo:frame-load", this.onPopularFrameLoad)
   }
 
   disconnect() {
@@ -44,6 +60,7 @@ export default class extends Controller {
     if (this.hasResultsHeadingTarget) {
       updateAriaLiveRegion(this.resultsHeadingTarget.textContent.trim())
     }
+    this.element.removeEventListener("turbo:frame-load", this.onPopularFrameLoad)
   }
 
   onTurboError(event) {
@@ -107,6 +124,55 @@ export default class extends Controller {
     this.searchFormTarget.classList.add("margin-bottom-4")
   }
 
+  onTabClick(event) {
+    this.pendingTabFocusId = event.currentTarget.id
+  }
+
+  onTabKeydown(event) {
+    const tabs = this.tabTargets
+    // finds which tab just received the keydown from the element listener it is bound to,
+    // i.e. whichever tab is currently focused).
+    const currentIndex = tabs.indexOf(event.currentTarget)
+    let newIndex
+
+    switch (event.key) {
+      case "ArrowLeft":
+      case "ArrowUp":
+        // Move to previous tab
+        // wraps from tab 0 to the last tab
+        // (+ tabs.length avoids a negative index before %)
+        newIndex = (currentIndex - 1 + tabs.length) % tabs.length
+        break
+      case "ArrowRight":
+      case "ArrowDown":
+        // Move to next tab
+        // wraps past the last tab to tab 0
+        newIndex = (currentIndex + 1) % tabs.length
+        break
+      case "Home":
+        newIndex = 0
+        break
+      case "End":
+        newIndex = tabs.length - 1
+        break
+      case " ":
+      case "Spacebar":
+        // NOTE: case is neccessary because the event targets (tab controls) are links
+        // links only activate on Enter keypress by default
+        event.preventDefault()
+        event.currentTarget.click()
+        return
+      default:
+        // no action, allow the browser's default handling to apply
+        return
+    }
+
+    event.preventDefault()
+    tabs.forEach((tab) => tab.setAttribute("tabindex", "-1"))
+    tabs[newIndex].setAttribute("tabindex", "0")
+    tabs[newIndex].focus()
+  }
+
   onSuccess(accountId) {
     this.userAccountIdTarget.value = accountId
     this.formTarget.submit()
@@ -133,6 +199,7 @@ export default class extends Controller {
       },
       onSuccess: this.onSuccess.bind(this),
       onExit: this.onExit.bind(this),
+      triggerElement: event.currentTarget,
     })
     await adapter.open()
   }

--- a/app/app/views/cbv/employer_searches/show.html.erb
+++ b/app/app/views/cbv/employer_searches/show.html.erb
@@ -65,18 +65,32 @@
     <input type="hidden" name="user[account_id]" data-cbv-employer-search-target="userAccountId">
   <% end %>
 
-  <h2><%= t(".popular_providers") %></h2>
+  <h2 id="popular_providers_heading"><%= t(".popular_providers") %></h2>
   <%= turbo_frame_tag "popular" do %>
-    <div class="grid-row maxw-mobile-lg margin-left-0 padding-left-0 margin-top-4">
+    <div class="grid-row maxw-mobile-lg margin-left-0 padding-left-0 margin-top-4" role="tablist" aria-labelledby="popular_providers_heading">
       <%= link_to t(".payroll_providers"), cbv_flow_employer_search_path(type: :payroll),
+        id: "payroll_providers_tab",
+        role: "tab",
+        tabindex: @selected_tab == "payroll" ? "0" : "-1",
+        aria: { selected: @selected_tab == "payroll", controls: "popular_providers_panel" },
         class: "grid-col usa-button margin-0 radius-right-0 #{@selected_tab != 'payroll' && 'usa-button--outline'}",
-        data: { turbo_frame: "popular", turbo_action: "advance", turbo_prefetch: false } %>
+        data: { turbo_frame: "popular", turbo_action: "advance", turbo_prefetch: false, "cbv-employer-search-target": "tab", action: "click->cbv-employer-search#onTabClick keydown->cbv-employer-search#onTabKeydown" } %>
       <%= link_to t(".app_based_providers"), cbv_flow_employer_search_path(type: :employer),
+        id: "app_based_providers_tab",
+        role: "tab",
+        tabindex: @selected_tab == "employer" ? "0" : "-1",
+        aria: { selected: @selected_tab == "employer", controls: "popular_providers_panel" },
         class: "grid-col usa-button margin-0 radius-left-0 #{@selected_tab != 'employer' && 'usa-button--outline'}",
-        data: { turbo_frame: "popular", turbo_action: "advance", turbo_prefetch: false } %>
+        data: { turbo_frame: "popular", turbo_action: "advance", turbo_prefetch: false, "cbv-employer-search-target": "tab", action: "click->cbv-employer-search#onTabClick keydown->cbv-employer-search#onTabKeydown" } %>
     </div>
 
-    <div class="grid-row grid-gap margin-top-2">
+    <div
+      id="popular_providers_panel"
+      role="tabpanel"
+      tabindex="0"
+      aria-labelledby="<%= @selected_tab == "payroll" ? "payroll_providers_tab" : "app_based_providers_tab" %>"
+      class="grid-row grid-gap margin-top-2"
+    >
       <% (ProviderSearchService.new(@cbv_flow.client_agency_id).top_aggregator_options(@selected_tab)).each do |provider| %>
         <div class="grid-col-4 tablet:grid-col-2 margin-top-2">
           <button

--- a/app/spec/javascript/controllers/employer_search.spec.js
+++ b/app/spec/javascript/controllers/employer_search.spec.js
@@ -502,3 +502,163 @@ describe("EmployerSearchController multiple instances on same page!", () => {
     expect(await trackUserAction).toBeCalledTimes(1)
   })
 })
+
+describe("EmployerSearchController tab keyboard navigation", () => {
+  let controllerElement
+  let payrollTab
+  let employerTab
+
+  beforeEach(async () => {
+    controllerElement = document.createElement("div")
+    controllerElement.setAttribute("data-controller", "cbv-employer-search")
+
+    payrollTab = document.createElement("a")
+    payrollTab.setAttribute("data-cbv-employer-search-target", "tab")
+    payrollTab.setAttribute("data-action", "keydown->cbv-employer-search#onTabKeydown")
+    payrollTab.setAttribute("tabindex", "0")
+
+    employerTab = document.createElement("a")
+    employerTab.setAttribute("data-cbv-employer-search-target", "tab")
+    employerTab.setAttribute("data-action", "keydown->cbv-employer-search#onTabKeydown")
+    employerTab.setAttribute("tabindex", "-1")
+
+    controllerElement.appendChild(payrollTab)
+    controllerElement.appendChild(employerTab)
+    document.body.appendChild(controllerElement)
+
+    await window.Stimulus.register("cbv-employer-search", EmployerSearchController)
+
+    payrollTab.focus()
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  it("moves focus and roving tabindex to the next tab on ArrowRight", () => {
+    payrollTab.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }))
+
+    expect(document.activeElement).toBe(employerTab)
+    expect(employerTab.getAttribute("tabindex")).toBe("0")
+    expect(payrollTab.getAttribute("tabindex")).toBe("-1")
+  })
+
+  it("wraps focus around to the last tab on ArrowLeft from the first tab", () => {
+    payrollTab.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }))
+
+    expect(document.activeElement).toBe(employerTab)
+    expect(employerTab.getAttribute("tabindex")).toBe("0")
+    expect(payrollTab.getAttribute("tabindex")).toBe("-1")
+  })
+
+  it("wraps focus around to the first tab on ArrowRight from the last tab", () => {
+    employerTab.focus()
+    employerTab.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }))
+
+    expect(document.activeElement).toBe(payrollTab)
+    expect(payrollTab.getAttribute("tabindex")).toBe("0")
+    expect(employerTab.getAttribute("tabindex")).toBe("-1")
+  })
+
+  it("moves focus to the last tab on End", () => {
+    payrollTab.dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true }))
+
+    expect(document.activeElement).toBe(employerTab)
+  })
+
+  it("moves focus to the first tab on Home", () => {
+    employerTab.focus()
+    employerTab.dispatchEvent(new KeyboardEvent("keydown", { key: "Home", bubbles: true }))
+
+    expect(document.activeElement).toBe(payrollTab)
+  })
+
+  it("activates the focused tab on Space without moving focus elsewhere", () => {
+    employerTab.focus()
+    vi.spyOn(employerTab, "click")
+
+    employerTab.dispatchEvent(
+      new KeyboardEvent("keydown", { key: " ", bubbles: true, cancelable: true })
+    )
+
+    expect(employerTab.click).toBeCalledTimes(1)
+  })
+
+  it("does not move focus or activate a tab on unrelated keys", () => {
+    vi.spyOn(payrollTab, "click")
+
+    payrollTab.dispatchEvent(new KeyboardEvent("keydown", { key: "a", bubbles: true }))
+
+    expect(document.activeElement).toBe(payrollTab)
+    expect(payrollTab.click).not.toBeCalled()
+    expect(payrollTab.getAttribute("tabindex")).toBe("0")
+  })
+})
+
+describe("EmployerSearchController tab focus restoration after frame reload", () => {
+  let controllerElement
+  let popularFrame
+  let employerTab
+
+  beforeEach(async () => {
+    controllerElement = document.createElement("div")
+    controllerElement.setAttribute("data-controller", "cbv-employer-search")
+
+    popularFrame = document.createElement("div")
+    popularFrame.id = "popular"
+
+    employerTab = document.createElement("a")
+    employerTab.id = "app_based_providers_tab"
+    employerTab.setAttribute("href", "/cbv/employer_search?type=employer")
+    employerTab.setAttribute("data-cbv-employer-search-target", "tab")
+    employerTab.setAttribute(
+      "data-action",
+      "click->cbv-employer-search#onTabClick keydown->cbv-employer-search#onTabKeydown"
+    )
+
+    popularFrame.appendChild(employerTab)
+    controllerElement.appendChild(popularFrame)
+    document.body.appendChild(controllerElement)
+
+    await window.Stimulus.register("cbv-employer-search", EmployerSearchController)
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  it("refocuses the activated tab's element (by id) once the popular frame finishes reloading", () => {
+    employerTab.click()
+
+    // Simulates Turbo tearing down and rebuilding the frame's contents on
+    // navigation: the original tab node is gone, replaced by a new one that
+    // happens to share the same id.
+    const reloadedTab = document.createElement("a")
+    reloadedTab.id = "app_based_providers_tab"
+    reloadedTab.setAttribute("href", "/cbv/employer_search?type=employer")
+    employerTab.replaceWith(reloadedTab)
+
+    popularFrame.dispatchEvent(new CustomEvent("turbo:frame-load", { bubbles: true }))
+
+    expect(document.activeElement).toBe(reloadedTab)
+  })
+
+  it("does nothing if the reloaded frame is not the popular frame", () => {
+    employerTab.click()
+    vi.spyOn(employerTab, "focus")
+
+    const otherFrame = document.createElement("div")
+    otherFrame.id = "employers"
+    controllerElement.appendChild(otherFrame)
+
+    otherFrame.dispatchEvent(new CustomEvent("turbo:frame-load", { bubbles: true }))
+
+    expect(employerTab.focus).not.toBeCalled()
+  })
+
+  it("does nothing if no tab was clicked before the frame reloads", () => {
+    expect(() =>
+      popularFrame.dispatchEvent(new CustomEvent("turbo:frame-load", { bubbles: true }))
+    ).not.toThrow()
+  })
+})

--- a/app/spec/javascript/controllers/employer_search.spec.js
+++ b/app/spec/javascript/controllers/employer_search.spec.js
@@ -30,8 +30,11 @@ describe("EmployerSearchController", () => {
     document.body.innerHTML = ""
   })
 
-  it("adds turbo:frame-missing, turbo:submit-start, and turbo:frame-load listeners on connect()", () => {
-    expect(stimulusElement.addEventListener).toBeCalledTimes(3)
+  it("adds turbo:frame-missing, turbo:submit-start, and two turbo:frame-load listeners on connect()", () => {
+    // Two separate turbo:frame-load listeners are registered: onFrameLoad
+    // (results-heading announcement) and onPopularFrameLoad (tab focus
+    // restoration) — they watch different frames and must both survive.
+    expect(stimulusElement.addEventListener).toBeCalledTimes(4)
     expect(stimulusElement.addEventListener).toHaveBeenCalledWith(
       "turbo:frame-missing",
       expect.any(Function)
@@ -42,19 +45,23 @@ describe("EmployerSearchController", () => {
       expect.any(Function)
     )
 
-    expect(stimulusElement.addEventListener).toHaveBeenCalledWith(
-      "turbo:frame-load",
-      expect.any(Function)
-    )
+    const frameLoadListenerCount = stimulusElement.addEventListener.mock.calls.filter(
+      ([eventName]) => eventName === "turbo:frame-load"
+    ).length
+    expect(frameLoadListenerCount).toBe(2)
   })
 
-  it("removes turbo:frame-missing, turbo:submit-start, and turbo:frame-load listeners on disconnect()", async () => {
+  it("removes all four listeners, including both turbo:frame-load ones, on disconnect()", async () => {
     await stimulusElement.remove()
-    expect(stimulusElement.removeEventListener).toBeCalledTimes(3)
+    expect(stimulusElement.removeEventListener).toBeCalledTimes(4)
     const removedEvents = stimulusElement.removeEventListener.mock.calls.map((c) => c[0])
     expect(removedEvents).toContain("turbo:frame-missing")
     expect(removedEvents).toContain("turbo:submit-start")
-    expect(removedEvents).toContain("turbo:frame-load")
+
+    const frameLoadRemovalCount = removedEvents.filter(
+      (eventName) => eventName === "turbo:frame-load"
+    ).length
+    expect(frameLoadRemovalCount).toBe(2)
   })
 })
 
@@ -660,5 +667,27 @@ describe("EmployerSearchController tab focus restoration after frame reload", ()
     expect(() =>
       popularFrame.dispatchEvent(new CustomEvent("turbo:frame-load", { bubbles: true }))
     ).not.toThrow()
+  })
+
+  it("still restores tab focus after the employers results frame has already loaded once", () => {
+    // Regression test: onFrameLoad (results-heading announcement, in the
+    // "employers" frame) used to tear down onPopularFrameLoad's listener as
+    // a side effect, permanently breaking tab focus restoration for the
+    // rest of the page's lifetime after any company-name search.
+    const employersFrame = document.createElement("div")
+    employersFrame.id = "employers"
+    controllerElement.appendChild(employersFrame)
+    employersFrame.dispatchEvent(new CustomEvent("turbo:frame-load", { bubbles: true }))
+
+    employerTab.click()
+
+    const reloadedTab = document.createElement("a")
+    reloadedTab.id = "app_based_providers_tab"
+    reloadedTab.setAttribute("href", "/cbv/employer_search?type=employer")
+    employerTab.replaceWith(reloadedTab)
+
+    popularFrame.dispatchEvent(new CustomEvent("turbo:frame-load", { bubbles: true }))
+
+    expect(document.activeElement).toBe(reloadedTab)
   })
 })


### PR DESCRIPTION
## Summary
Adds ARIA tabs semantics and keyboard behavior to the "Payroll providers" / "App-based employers" toggle on the employer search step. Previously announced as plain unrelated links to screen reader users despite behaving visually like tabs.

## Type of Change
Check all that apply.
- [x] Bug
- [ ] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
- Added `role="tablist"`/`role="tab"`/`role="tabpanel"`, `aria-selected`, `aria-controls`/`aria-labelledby`, and roving `tabindex` to the popular-providers tab links and panel in `show.html.erb`
    - [Roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) is what makes the two links behave as one stop in the page's Tab order (a single composite widget) instead of two separate stops.
- Extended the `cbv-employer-search` Stimulus controller with `onTabKeydown`: Left/Right/Up/Down roam focus between tabs with wraparound, Home/End jump to the first/last tab, and Space activates the focused tab (Enter already works natively on links)
- Added focus restoration (`onTabClick` + `onPopularFrameLoad`) so keyboard focus stays on the tab that was just activated after Turbo reloads the `popular` frame, instead of being lost to the top of the page
- Added Vitest coverage for the keyboard navigation and focus-restoration behavior

## Checklist
- [x] Tests added/updated
- [ ] Docs updated (if needed)

## Notes for Reviewers
- The focus-restoration piece exists because `data-turbo-action="advance"` on these links causes Turbo to tear down and rebuild the frame's contents on every tab activation, which drops keyboard focus
- Provider ordering/alphabetization is explicitly out of scope here (tracked as a follow-up ticket).

### Keyboard only
https://github.com/user-attachments/assets/8deca7f2-4863-4deb-858c-586c1ef1a33a

### Narrator on Edge
https://github.com/user-attachments/assets/730b1fde-8320-4573-b61f-5ef44f464bf3

