### PR TITLE
Character counter modifications

### DIFF
--- a/app/app/javascript/controllers/cbv/character_count_controller.js
+++ b/app/app/javascript/controllers/cbv/character_count_controller.js
@@ -2,6 +2,8 @@ import { Controller } from "@hotwired/stimulus"
 
 const ERROR_CLASS = "usa-error-message"
 const HINT_CLASS = "usa-hint"
+// Matches USWDS's own debounce delay for its character count SR announcements.
+const SR_ANNOUNCEMENT_DELAY = 1000
 
 export default class extends Controller {
   static targets = ["input", "message", "srMessage", "submitButton"]
@@ -12,7 +14,14 @@ export default class extends Controller {
   }
 
   connect() {
-    this.update()
+    // Announce the initial state right away (immediate: true) — there's no
+    // typing to debounce yet, and USWDS's own implementation sets its
+    // initial SR text synchronously too.
+    this.render({ immediate: true })
+  }
+
+  disconnect() {
+    clearTimeout(this.srTimeout)
   }
 
   guardSubmit(event) {
@@ -22,38 +31,65 @@ export default class extends Controller {
   }
 
   update() {
+    // Every keystroke goes through here without `immediate`, so the SR
+    // announcement gets debounced (see announceToScreenReader) instead of
+    // firing on every character typed.
+    this.render()
+  }
+
+  render({ immediate = false } = {}) {
     const length = this.inputTarget.value.length
     const over = length - this.maxlengthValue
 
     if (over > 0) {
-      this.showError(over)
+      this.showError(over, immediate)
     } else {
-      this.showCount(length)
+      this.showCount(length, immediate)
     }
   }
 
-  showCount(length) {
-    this.messageTarget.textContent = `${length}/${this.maxlengthValue}`
+  showCount(length, immediate) {
+    const message = `${length}/${this.maxlengthValue}`
+    this.messageTarget.textContent = message
     this.messageTarget.classList.remove(ERROR_CLASS)
     this.messageTarget.classList.add(HINT_CLASS)
-    this.srMessageTarget.textContent = ""
+    this.announceToScreenReader(message, immediate)
 
     this.inputTarget.classList.remove("usa-input--error")
     this.inputTarget.removeAttribute("aria-invalid")
     this.enableSubmit()
   }
 
-  showError(over) {
+  showError(over, immediate) {
     const message = `${this.overLimitTextValue.replace("{count}", over)} ${this.shortenTextValue}`
 
     this.messageTarget.textContent = message
     this.messageTarget.classList.remove(HINT_CLASS)
     this.messageTarget.classList.add(ERROR_CLASS)
-    this.srMessageTarget.textContent = message
+    this.announceToScreenReader(message, immediate)
 
     this.inputTarget.classList.add("usa-input--error")
     this.inputTarget.setAttribute("aria-invalid", "true")
     this.disableSubmit()
+  }
+
+  announceToScreenReader(message, immediate) {
+    // The visual counter (messageTarget) always updates instantly above —
+    // this only controls the separate aria-live region. Screen readers
+    // announce aria-live changes as soon as they land, so writing on every
+    // keystroke would read the count aloud character by character. Instead
+    // we clear any pending write and schedule a new one, so only the value
+    // from the last keystroke before a pause actually reaches the live
+    // region — a trailing-edge debounce, same delay USWDS itself uses.
+    clearTimeout(this.srTimeout)
+
+    if (immediate) {
+      this.srMessageTarget.textContent = message
+    } else {
+      this.srTimeout = setTimeout(() => {
+        this.srMessageTarget.textContent = message
+      }, SR_ANNOUNCEMENT_DELAY)
+    }
   }
 
   enableSubmit() {

--- a/app/app/views/cbv/payment_details/show.html.erb
+++ b/app/app/views/cbv/payment_details/show.html.erb
@@ -57,8 +57,9 @@
   <%= form_with(model: @cbv_flow, url: cbv_flow_payment_details_path, method: :patch, class: "usa-form usa-form--large", data: { action: "submit->cbv-character-count#guardSubmit" }) do |form| %>
     <%= hidden_field_tag "user[account_id]", params[:user][:account_id] %>
     <%= form.label :additional_information, t(".additional_information_label", agency_acronym: agency_acronym_or_full_name), class: "usa-label", id: "additional_information_description" %>
-    <%= form.text_area :additional_information, class: "usa-textarea", rows: 5, value: @account_comment, placeholder: t(".additional_information_placeholder"), "aria-labelledby": "additional_info_header additional_information_description", "aria-describedby": "additional_information_count", data: { cbv_character_count_target: "input", action: "input->cbv-character-count#update" } %>
-    <%= content_tag :div, "0/1000", id: "additional_information_count", class: "usa-hint margin-top-1", data: { cbv_character_count_target: "message" } %>
+    <%= content_tag :span, t(".character_count_description"), id: "additional_information_count_description", class: "usa-sr-only" %>
+    <%= form.text_area :additional_information, class: "usa-textarea", rows: 5, value: @account_comment, placeholder: t(".additional_information_placeholder"), "aria-labelledby": "additional_info_header additional_information_description", "aria-describedby": "additional_information_count_description", data: { cbv_character_count_target: "input", action: "input->cbv-character-count#update" } %>
+    <%= content_tag :div, "0/1000", class: "usa-hint margin-top-1", "aria-hidden": "true", data: { cbv_character_count_target: "message" } %>
     <%= content_tag :div, "", class: "usa-sr-only", "aria-live": "polite", data: { cbv_character_count_target: "srMessage" } %>
     <%= form.submit t(".continue"), class: "usa-button usa-button--primary", data: { cbv_character_count_target: "submitButton" } %>
   <% end %>

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -400,6 +400,7 @@ en:
         additional_information_header: Additional comments (Optional)
         additional_information_label: Share any comments or additional information about the income details above that you’d like %{agency_acronym} to know. For example, you can share if the information is inaccurate or if you’re no longer working at that job.
         additional_information_placeholder: Enter up to 1000 characters
+        character_count_description: You can enter up to 1000 characters
         character_count_over_limit: "{count} characters over limit."
         character_count_shorten: Please make your comment shorter.
         continue: Continue

--- a/app/config/locales/en.yml
+++ b/app/config/locales/en.yml
@@ -400,7 +400,7 @@ en:
         additional_information_header: Additional comments (Optional)
         additional_information_label: Share any comments or additional information about the income details above that you’d like %{agency_acronym} to know. For example, you can share if the information is inaccurate or if you’re no longer working at that job.
         additional_information_placeholder: Enter up to 1000 characters
-        character_count_description: You can enter up to 1000 characters
+        character_count_description: 1000 characters allowed
         character_count_over_limit: "{count} characters over limit."
         character_count_shorten: Please make your comment shorter.
         continue: Continue

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -302,6 +302,7 @@ es:
         additional_information_header: Comentarios adicionales (Opcional)
         additional_information_label: Comparta cualquier comentario o información adicional sobre los detalles de pago anteriores que desea que %{agency_acronym} conozca. Por ejemplo, puede compartir si la información es inexacta o si ya no trabaja en ese empleo.
         additional_information_placeholder: Introduzca hasta 1000 caracteres
+        character_count_description: Puede ingresar hasta 1000 caracteres
         character_count_over_limit: Hay {count} caracteres de más.
         character_count_shorten: Acorte el comentario, por favor.
         continue: Continuar

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -302,7 +302,7 @@ es:
         additional_information_header: Comentarios adicionales (Opcional)
         additional_information_label: Comparta cualquier comentario o información adicional sobre los detalles de pago anteriores que desea que %{agency_acronym} conozca. Por ejemplo, puede compartir si la información es inexacta o si ya no trabaja en ese empleo.
         additional_information_placeholder: Introduzca hasta 1000 caracteres
-        character_count_description: 1000 caracteres permitidos
+        character_count_description: Hasta 1000 caracteres
         character_count_over_limit: Hay {count} caracteres de más.
         character_count_shorten: Acorte el comentario, por favor.
         continue: Continuar

--- a/app/config/locales/es.yml
+++ b/app/config/locales/es.yml
@@ -302,7 +302,7 @@ es:
         additional_information_header: Comentarios adicionales (Opcional)
         additional_information_label: Comparta cualquier comentario o información adicional sobre los detalles de pago anteriores que desea que %{agency_acronym} conozca. Por ejemplo, puede compartir si la información es inexacta o si ya no trabaja en ese empleo.
         additional_information_placeholder: Introduzca hasta 1000 caracteres
-        character_count_description: Puede ingresar hasta 1000 caracteres
+        character_count_description: 1000 caracteres permitidos
         character_count_over_limit: Hay {count} caracteres de más.
         character_count_shorten: Acorte el comentario, por favor.
         continue: Continuar

--- a/app/spec/javascript/controllers/cbv/character_count_controller.spec.js
+++ b/app/spec/javascript/controllers/cbv/character_count_controller.spec.js
@@ -61,17 +61,20 @@ describe("CharacterCountController", () => {
 
     application = Application.start()
     application.register("character-count", CharacterCountController)
+
+    vi.useFakeTimers()
   })
 
   afterEach(() => {
     application.stop()
     document.body.innerHTML = ""
+    vi.useRealTimers()
     vi.restoreAllMocks()
   })
 
-  it("shows an initial count, enables the submit button, and keeps it focusable", () => {
+  it("shows an initial count, announces it immediately, enables the submit button, and keeps it focusable", () => {
     expect(message.textContent).toBe("0/1000")
-    expect(srMessage.textContent).toBe("")
+    expect(srMessage.textContent).toBe("0/1000")
     expect(submitButton.disabled).toBe(false)
     expect(submitButton.getAttribute("aria-disabled")).toBe("false")
 
@@ -83,9 +86,16 @@ describe("CharacterCountController", () => {
       setValue("a".repeat(500))
     })
 
-    it("updates the visible counter without announcing anything, and allows submission", () => {
+    it("updates the visible counter immediately, but delays the screen reader announcement", () => {
       expect(message.textContent).toBe("500/1000")
-      expect(srMessage.textContent).toBe("")
+      expect(srMessage.textContent).toBe("0/1000")
+
+      vi.advanceTimersByTime(1000)
+
+      expect(srMessage.textContent).toBe("500/1000")
+    })
+
+    it("allows submission", () => {
       expect(input.hasAttribute("aria-invalid")).toBe(false)
       expect(submitButton.disabled).toBe(false)
       expect(submitButton.getAttribute("aria-disabled")).toBe("false")
@@ -99,10 +109,14 @@ describe("CharacterCountController", () => {
       setValue("a".repeat(1050))
     })
 
-    it("shows the combined error message and marks the field invalid", () => {
+    it("shows the combined error message immediately, but delays the screen reader announcement", () => {
       const expected = "50 characters over limit. Please make your comment shorter."
 
       expect(message.textContent).toBe(expected)
+      expect(srMessage.textContent).toBe("0/1000")
+
+      vi.advanceTimersByTime(1000)
+
       expect(srMessage.textContent).toBe(expected)
       expect(input.getAttribute("aria-invalid")).toBe("true")
     })
@@ -124,12 +138,19 @@ describe("CharacterCountController", () => {
 
       it("clears the error state, re-enables the submit button, and allows submission", () => {
         expect(message.textContent).toBe("200/1000")
-        expect(srMessage.textContent).toBe("")
         expect(input.hasAttribute("aria-invalid")).toBe(false)
         expect(submitButton.disabled).toBe(false)
         expect(submitButton.getAttribute("aria-disabled")).toBe("false")
 
         expect(dispatchSubmit().defaultPrevented).toBe(false)
+      })
+
+      it("delays the screen reader announcement of the cleared state", () => {
+        expect(srMessage.textContent).toBe("0/1000")
+
+        vi.advanceTimersByTime(1000)
+
+        expect(srMessage.textContent).toBe("200/1000")
       })
     })
   })


### PR DESCRIPTION
## Summary
Fixed the accessibility implementation of the character counter on the payment details "additional comments" field. USWDS's actual runtime behavior has three parts, this change brings our implementation in line with that real behavior.

## Type of Change
Check all that apply.
- [x] Bug
- [ ] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
- Added a static, screen-reader-only description ("You can enter up to 1000 characters") wired to the textarea via aria-describedby — previously the field was using the visual character count
- Kept the visual "N/1000" counter aria-hidden="true" so it's never read directly by a screen reader
- Debounced the aria-live region update to fire ~1000ms after the user stops typing (matching USWDS's own delay), instead of announcing on every keystroke or not at all
- Added character_count_description translation key to en.yml and es.yml
- Updated character_count_controller.js to distinguish an immediate announcement (on connect) from debounced announcements (on typing), with disconnect() clearing the pending timer
- Updated the Stimulus controller spec to use fake timers and assert the delayed-announcement behavior

## Checklist
- [x] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
- The Spanish translation for the new character_count_description key ("Puede ingresar hasta 1000 caracteres") was generated by Claude and needs confirmation.