### PR TITLE
Drew/pf 741 argyle modal focus 2

### DIFF
--- a/app/app/javascript/adapters/ArgyleModalAdapter.ts
+++ b/app/app/javascript/adapters/ArgyleModalAdapter.ts
@@ -9,6 +9,15 @@ import {
 
 export default class ArgyleModalAdapter extends ModalAdapter {
   private seenError = false
+
+  // Covers both onClose and onError, which already funnel into this. Must
+  // wait for the exit callback (which re-enables the trigger button) to run
+  // before restoring focus - a disabled button silently rejects .focus().
+  async onExit(eventPayload: any = {}) {
+    await super.onExit(eventPayload)
+    this.restoreFocus()
+  }
+
   async open() {
     const locale = getDocumentLocale()
 
@@ -62,13 +71,13 @@ export default class ArgyleModalAdapter extends ModalAdapter {
       await trackUserAction("ApplicantEncounteredModalAdapterError", {
         message: "Missing requestData from init() function",
       })
-      this.onExit()
+      await this.onExit()
     }
   }
 
   async onError(err: LinkError) {
     await trackUserAction("ApplicantEncounteredArgyleError", err)
-    this.onExit()
+    await this.onExit()
   }
 
   async onClose() {

--- a/app/app/javascript/adapters/ModalAdapter.ts
+++ b/app/app/javascript/adapters/ModalAdapter.ts
@@ -1,9 +1,12 @@
 import type { RequestData, ModalAdapterArgs } from "./ModalAdapter.types.ts"
+import { restoreFocusTo } from "@js/utilities/modalFocusContainment.js"
 
 export abstract class ModalAdapter {
   requestData?: RequestData
   successCallback?: Function
   exitCallback?: Function
+  triggerElement?: HTMLElement
+  fallbackFocusElement?: HTMLElement
   modalSdk: Argyle | Pinwheel
 
   abstract open(): void
@@ -23,6 +26,16 @@ export abstract class ModalAdapter {
     if (args.requestData) {
       this.requestData = args.requestData
     }
+    if (args.triggerElement) {
+      this.triggerElement = args.triggerElement
+    }
+    if (args.fallbackFocusElement) {
+      this.fallbackFocusElement = args.fallbackFocusElement
+    }
+  }
+
+  restoreFocus() {
+    restoreFocusTo(this.triggerElement, this.fallbackFocusElement)
   }
 
   async onExit(eventPayload: any = {}) {

--- a/app/app/javascript/adapters/ModalAdapter.types.ts
+++ b/app/app/javascript/adapters/ModalAdapter.types.ts
@@ -2,6 +2,8 @@ export interface ModalAdapterArgs {
   requestData: RequestData
   onSuccess?: Function
   onExit?: Function
+  triggerElement?: HTMLElement
+  fallbackFocusElement?: HTMLElement
 }
 
 export interface RequestData {

--- a/app/app/javascript/controllers/cbv/employer_search.js
+++ b/app/app/javascript/controllers/cbv/employer_search.js
@@ -15,6 +15,7 @@ export default class extends Controller {
     "searchForm",
     "resultsHeading",
     "tab",
+    "pageHeading",
   ]
 
   static values = {
@@ -200,6 +201,7 @@ export default class extends Controller {
       onSuccess: this.onSuccess.bind(this),
       onExit: this.onExit.bind(this),
       triggerElement: event.currentTarget,
+      fallbackFocusElement: this.hasPageHeadingTarget ? this.pageHeadingTarget : undefined,
     })
     await adapter.open()
   }

--- a/app/app/javascript/utilities/modalFocusContainment.ts
+++ b/app/app/javascript/utilities/modalFocusContainment.ts
@@ -1,0 +1,50 @@
+// How long, and how often, to keep checking whether focus has fallen back
+// to document.body after we set it elsewhere.
+const FOCUS_GUARD_WINDOW_MS = 2000
+const FOCUS_GUARD_POLL_MS = 100
+
+// Polls document.activeElement instead of listening for a focus event:
+// focus falling back to <body> (nothing else taking it) doesn't reliably
+// dispatch a listenable focusout/focusin event, so reading the state
+// directly is the only dependable signal. Only corrects when activeElement
+// is exactly <body> - once it becomes any other real element, that's a
+// legitimate focus change (e.g. the user tabbing away) and checking stops
+// for good.
+function guardFocus(target: HTMLElement): void {
+  const deadline = Date.now() + FOCUS_GUARD_WINDOW_MS
+  const check = () => {
+    if (Date.now() >= deadline || !document.body.contains(target)) return
+    if (document.activeElement === target) {
+      setTimeout(check, FOCUS_GUARD_POLL_MS)
+      return
+    }
+    if (document.activeElement === document.body) {
+      target.focus()
+      setTimeout(check, FOCUS_GUARD_POLL_MS)
+    }
+    // Anything else: focus moved to a different real element - leave it alone.
+  }
+  setTimeout(check, FOCUS_GUARD_POLL_MS)
+}
+
+/**
+ * Restores focus to `triggerElement` if it's still in the DOM, else
+ * `fallback`, else <body> as an absolute last resort. Focuses immediately,
+ * then `guardFocus` keeps watch briefly in case a third-party widget's own
+ * teardown resets focus back to <body> afterward.
+ */
+export function restoreFocusTo(triggerElement?: HTMLElement, fallback?: HTMLElement): void {
+  if (triggerElement && document.body.contains(triggerElement)) {
+    triggerElement.focus()
+    guardFocus(triggerElement)
+    return
+  }
+  if (fallback && document.body.contains(fallback)) {
+    fallback.focus()
+    guardFocus(fallback)
+    return
+  }
+  document.body.setAttribute("tabindex", "-1")
+  document.body.focus()
+  document.body.removeAttribute("tabindex")
+}

--- a/app/app/views/cbv/employer_searches/show.html.erb
+++ b/app/app/views/cbv/employer_searches/show.html.erb
@@ -7,7 +7,7 @@
     <% end %>
   </div>
 
-  <h1 class="margin-top-0 display-flex flex-column flex-align-start gap-1 flex-align-self-stretch padding-bottom-3">
+  <h1 tabindex="-1" data-cbv-employer-search-target="pageHeading" class="margin-top-0 display-flex flex-column flex-align-start gap-1 flex-align-self-stretch padding-bottom-3">
     <%= t(".header") %>
   </h1>
   <div class="display-flex flex-align-center text-ink font-sans-md">

--- a/app/spec/e2e/cbv_flow_spec.rb
+++ b/app/spec/e2e/cbv_flow_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe "e2e CBV flow test", type: :feature, js: true do
     # /cbv/employer_search
     verify_page(page, title: I18n.t("cbv.employer_searches.show.header"), wait: 10)
 
+    # Note: @e2e.replay_modal_callbacks below replays a fixed recorded fixture
+    # (aggregator_modal_callbacks.yml) rather than driving the real Argyle SDK,
+    # so this only exercises the successful-login path (onSuccess) - it can't
+    # verify focus restoration after a close/cancel (see the separate "returns
+    # focus to the trigger button after the Argyle modal is closed without
+    # logging in" test below for that case).
     @e2e.replay_modal_callbacks(page.driver.browser) do
       click_button "Paychex"
     end
@@ -81,6 +87,39 @@ RSpec.describe "e2e CBV flow test", type: :feature, js: true do
     # /cbv/success
     verify_page(page, title: I18n.t("cbv.successes.show.header", agency_acronym: "CBV"))
     # TODO: Test PDF rendering by writing it to a file
+  end
+
+  it "returns focus to the trigger button after the Argyle modal is closed without logging in" do
+    raise "Argyle not in supported_providers!" unless Rails.application.config.supported_providers.include?(:argyle)
+
+    # This uses a hand-rolled replay payload (rather than @e2e.replay_modal_callbacks,
+    # which always plays back the fixed "aggregator_modal_callbacks.yml" recording)
+    # because that recording only ever completes a successful login - it never
+    # exercises Argyle's onClose callback, so it can't be used to verify focus
+    # restoration after the user closes the modal without logging in.
+    page.driver.browser.execute_script(<<~JS)
+      window.sessionStorage.setItem("e2eInvokedCallbacks", "[]");
+      window.sessionStorage.setItem(
+        "e2eCallbacksToInvoke",
+        #{JSON.generate([ { callbackName: "onClose", callbackArguments: [] } ]).inspect}
+      );
+    JS
+
+    # /cbv/entry
+    visit URI(root_url).request_uri
+    visit URI(cbv_flow_invitation.to_url).request_uri
+    find("label", text: I18n.t("cbv.entries.show.checkbox.default", agency_full_name: I18n.t("shared.agency_full_name.sandbox"))).click
+    click_button I18n.t("cbv.entries.show.continue")
+
+    # /cbv/employer_search
+    verify_page(page, title: I18n.t("cbv.employer_searches.show.header"), wait: 10)
+    click_button "Paychex"
+
+    # Closing without logging in shouldn't navigate away from employer_search...
+    verify_page(page, title: I18n.t("cbv.employer_searches.show.header"), wait: 10)
+    # ...and focus should return to the button that opened the modal, not fall
+    # back to the top of the page.
+    expect(page.evaluate_script("document.activeElement.textContent")).to include("Paychex")
   end
 
   it "ensures the back buttons work", :allow_playback_repeats do

--- a/app/spec/e2e/cbv_flow_spec.rb
+++ b/app/spec/e2e/cbv_flow_spec.rb
@@ -92,19 +92,6 @@ RSpec.describe "e2e CBV flow test", type: :feature, js: true do
   it "returns focus to the trigger button after the Argyle modal is closed without logging in" do
     raise "Argyle not in supported_providers!" unless Rails.application.config.supported_providers.include?(:argyle)
 
-    # This uses a hand-rolled replay payload (rather than @e2e.replay_modal_callbacks,
-    # which always plays back the fixed "aggregator_modal_callbacks.yml" recording)
-    # because that recording only ever completes a successful login - it never
-    # exercises Argyle's onClose callback, so it can't be used to verify focus
-    # restoration after the user closes the modal without logging in.
-    page.driver.browser.execute_script(<<~JS)
-      window.sessionStorage.setItem("e2eInvokedCallbacks", "[]");
-      window.sessionStorage.setItem(
-        "e2eCallbacksToInvoke",
-        #{JSON.generate([ { callbackName: "onClose", callbackArguments: [] } ]).inspect}
-      );
-    JS
-
     # /cbv/entry
     visit URI(root_url).request_uri
     visit URI(cbv_flow_invitation.to_url).request_uri
@@ -113,6 +100,25 @@ RSpec.describe "e2e CBV flow test", type: :feature, js: true do
 
     # /cbv/employer_search
     verify_page(page, title: I18n.t("cbv.employer_searches.show.header"), wait: 10)
+
+    # This uses a hand-rolled replay payload (rather than @e2e.replay_modal_callbacks,
+    # which always plays back the fixed "aggregator_modal_callbacks.yml" recording)
+    # because that recording only ever completes a successful login - it never
+    # exercises Argyle's onClose callback, so it can't be used to verify focus
+    # restoration after the user closes the modal without logging in.
+    #
+    # Must run after the initial navigation above, not before it - executing
+    # script against sessionStorage before the browser has visited any real
+    # page throws "Access is denied for this document" (no origin yet to
+    # scope storage to).
+    page.driver.browser.execute_script(<<~JS)
+      window.sessionStorage.setItem("e2eInvokedCallbacks", "[]");
+      window.sessionStorage.setItem(
+        "e2eCallbacksToInvoke",
+        #{JSON.generate([ { callbackName: "onClose", callbackArguments: [] } ]).inspect}
+      );
+    JS
+
     click_button "Paychex"
 
     # Closing without logging in shouldn't navigate away from employer_search...

--- a/app/spec/javascript/adapters/ArgyleModalAdapter.spec.js
+++ b/app/spec/javascript/adapters/ArgyleModalAdapter.spec.js
@@ -422,4 +422,59 @@ describe("ArgyleModalAdapter", () => {
       expect(trackUserAction.mock.calls[1][1]).toMatchSnapshot()
     })
   })
+
+  // Uses its own adapter instance/args (not the shared module-level
+  // `modalAdapterArgs`/`adapter`/`triggers` from the outer beforeEach) so
+  // `triggerElement` doesn't leak into unrelated tests.
+  describe("focus restoration", () => {
+    afterEach(() => {
+      document.body.innerHTML = ""
+    })
+
+    it("restores focus to the triggerElement after the modal closes", async () => {
+      const trigger = document.createElement("button")
+      document.body.appendChild(trigger)
+
+      const localAdapter = new ArgyleModalAdapter(Argyle)
+      localAdapter.init({ ...modalAdapterArgs, triggerElement: trigger })
+      const localTriggers = await localAdapter.open()
+
+      await localTriggers.triggerClose()
+
+      expect(document.activeElement).toBe(trigger)
+    })
+
+    it("restores focus to the triggerElement after the modal errors", async () => {
+      const trigger = document.createElement("button")
+      document.body.appendChild(trigger)
+
+      const localAdapter = new ArgyleModalAdapter(Argyle)
+      localAdapter.init({ ...modalAdapterArgs, triggerElement: trigger })
+      const localTriggers = await localAdapter.open()
+
+      await localTriggers.triggerError()
+
+      expect(document.activeElement).toBe(trigger)
+    })
+
+    it("falls back to fallbackFocusElement when the trigger was removed before the modal closed", async () => {
+      const trigger = document.createElement("button")
+      const fallback = document.createElement("h1")
+      fallback.setAttribute("tabindex", "-1")
+      document.body.append(trigger, fallback)
+
+      const localAdapter = new ArgyleModalAdapter(Argyle)
+      localAdapter.init({
+        ...modalAdapterArgs,
+        triggerElement: trigger,
+        fallbackFocusElement: fallback,
+      })
+      const localTriggers = await localAdapter.open()
+
+      trigger.remove()
+      await localTriggers.triggerClose()
+
+      expect(document.activeElement).toBe(fallback)
+    })
+  })
 })

--- a/app/spec/javascript/controllers/employer_search.spec.js
+++ b/app/spec/javascript/controllers/employer_search.spec.js
@@ -1,5 +1,6 @@
 import { vi, describe, beforeEach, it, expect } from "vitest"
 import EmployerSearchController from "@js/controllers/cbv/employer_search"
+import ArgyleModalAdapter from "@js/adapters/ArgyleModalAdapter"
 import { fetchPinwheelToken, fetchArgyleToken, trackUserAction } from "@js/utilities/api"
 import loadScript from "load-script"
 import {
@@ -149,6 +150,16 @@ describe("EmployerSearchController with argyle", () => {
     expect(await fetchArgyleToken).toBeCalled()
     expect(await fetchArgyleToken.mock.results[0].value).toStrictEqual(mockArgyleAuthToken)
     expect(fetchArgyleToken.mock.calls[0]).toMatchSnapshot()
+  })
+
+  it("passes the clicked element as triggerElement to the adapter", async () => {
+    const initSpy = vi.spyOn(ArgyleModalAdapter.prototype, "init")
+
+    await stimulusElement.click()
+
+    expect(initSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ triggerElement: stimulusElement })
+    )
   })
 })
 
@@ -689,5 +700,68 @@ describe("EmployerSearchController tab focus restoration after frame reload", ()
     popularFrame.dispatchEvent(new CustomEvent("turbo:frame-load", { bubbles: true }))
 
     expect(document.activeElement).toBe(reloadedTab)
+  })
+})
+
+describe("EmployerSearchController modal focus restoration", () => {
+  let controllerElement
+  let stimulusElement
+  let pageHeading
+
+  beforeEach(async () => {
+    controllerElement = document.createElement("div")
+    controllerElement.setAttribute("data-controller", "cbv-employer-search")
+
+    pageHeading = document.createElement("h1")
+    pageHeading.setAttribute("tabindex", "-1")
+    pageHeading.setAttribute("data-cbv-employer-search-target", "pageHeading")
+    controllerElement.appendChild(pageHeading)
+
+    stimulusElement = document.createElement("button")
+    stimulusElement.setAttribute("data-action", "cbv-employer-search#select")
+    stimulusElement.setAttribute("data-cbv-employer-search-target", "employerButton")
+    stimulusElement.setAttribute("data-response-type", "employer")
+    stimulusElement.setAttribute("data-id", "uuid")
+    stimulusElement.setAttribute("data-is-default-option", false)
+    stimulusElement.setAttribute("data-name", "test-name")
+    stimulusElement.setAttribute("data-provider-name", "argyle")
+    controllerElement.appendChild(stimulusElement)
+
+    document.body.appendChild(controllerElement)
+
+    await window.Stimulus.register("cbv-employer-search", EmployerSearchController)
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  function getLatestArgyleTriggers() {
+    const createCallIndex = mockArgyleModule.create.mock.results.length - 1
+    return mockArgyleModule.create.mock.results[createCallIndex].value.open.mock.results[0].value
+  }
+
+  it("returns focus to the trigger button after the modal closes", async () => {
+    await stimulusElement.click()
+    // select()/open() run several sequential awaits (trackUserAction, then
+    // fetchArgyleToken) before Argyle.create() is actually called; click()
+    // isn't itself awaited by anything, so give the chain time to reach it.
+    await vi.waitFor(() => expect(mockArgyleModule.create).toHaveBeenCalled())
+    const triggers = getLatestArgyleTriggers()
+
+    await triggers.triggerClose()
+
+    expect(document.activeElement).toBe(stimulusElement)
+  })
+
+  it("falls back to the page heading if the trigger button was removed before the modal closed", async () => {
+    await stimulusElement.click()
+    await vi.waitFor(() => expect(mockArgyleModule.create).toHaveBeenCalled())
+    const triggers = getLatestArgyleTriggers()
+
+    stimulusElement.remove()
+    await triggers.triggerClose()
+
+    expect(document.activeElement).toBe(pageHeading)
   })
 })

--- a/app/spec/javascript/utilities/modalFocusContainment.spec.js
+++ b/app/spec/javascript/utilities/modalFocusContainment.spec.js
@@ -1,0 +1,95 @@
+import { describe, it, expect, afterEach } from "vitest"
+import { restoreFocusTo } from "@js/utilities/modalFocusContainment"
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+describe("restoreFocusTo", () => {
+  afterEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  it("focuses the trigger element immediately, with no upfront delay", () => {
+    const trigger = document.createElement("button")
+    document.body.appendChild(trigger)
+
+    restoreFocusTo(trigger)
+
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it("falls back to the fallback element when the trigger was removed", () => {
+    const trigger = document.createElement("button")
+    // Mirrors the real page heading, which needs tabindex="-1" to be
+    // programmatically focusable despite not being an interactive element.
+    const fallback = document.createElement("h1")
+    fallback.setAttribute("tabindex", "-1")
+    document.body.appendChild(fallback)
+    // trigger deliberately never attached, simulating DOM churn while the modal was open
+
+    restoreFocusTo(trigger, fallback)
+
+    expect(document.activeElement).toBe(fallback)
+  })
+
+  it("falls back to document.body when neither trigger nor fallback is available", () => {
+    restoreFocusTo(undefined, undefined)
+
+    expect(document.activeElement).toBe(document.body)
+  })
+
+  it("reclaims focus if it falls back to document.body shortly afterward", async () => {
+    const trigger = document.createElement("button")
+    document.body.appendChild(trigger)
+
+    restoreFocusTo(trigger)
+    trigger.blur() // nothing else takes focus, so activeElement falls back to <body>
+    expect(document.activeElement).toBe(document.body)
+
+    await wait(150)
+
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it("keeps correcting if focus falls back to document.body more than once", async () => {
+    const trigger = document.createElement("button")
+    document.body.appendChild(trigger)
+
+    restoreFocusTo(trigger)
+    trigger.blur()
+    await wait(150)
+    expect(document.activeElement).toBe(trigger)
+
+    trigger.blur()
+    await wait(150)
+
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it("does not fight focus that moves to a different real element", async () => {
+    const trigger = document.createElement("button")
+    const other = document.createElement("button")
+    document.body.append(trigger, other)
+
+    restoreFocusTo(trigger)
+    other.focus()
+
+    await wait(150)
+
+    expect(document.activeElement).toBe(other)
+  })
+
+  it("no longer reclaims focus once the guard window has elapsed", async () => {
+    const trigger = document.createElement("button")
+    document.body.appendChild(trigger)
+
+    restoreFocusTo(trigger)
+    await wait(2100) // guard window (2000ms) has elapsed with no focus change
+
+    trigger.blur()
+    await wait(150)
+
+    expect(document.activeElement).toBe(document.body)
+  }, 10000)
+})


### PR DESCRIPTION
## Summary
Restores keyboard/AT focus to the button that opened the Argyle login modal after it closes, instead of dropping focus back to the top of the page. Including a fall-back as well, just in case the trigger no longer exists on the page. 

## Type of Change
Check all that apply.
- [x] Bug
- [ ] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
- ModalAdapter/ModalAdapterArgs: added `triggerElement`/`fallbackFocusElement` plumbing and a `restoreFocus()` method.
- ArgyleModalAdapter: restores focus to the trigger (or fallback) once the modal exits via close, error, or the missing-requestData path; fixed two call sites that fired onExit() without awaiting it.
- employer_search.js / show.html.erb: added a `pageHeading` target on the page's `<h1>` as the fallback focus target for ifthe trigger button no longer exists
- modalFocusContainment.ts (new): `restoreFocusTo` sets focus immediately, then briefly polls for the specific case where the third-party widget's own teardown resets focus back to <body> afterward, self-correcting without fighting legitimate focus changes.
- Vitest coverage for the adapter, the controller wiring, and the polling guard; two new Capybara e2e assertions (one hand-rolled to exercise the close-without-logging-in path, since the existing recorded fixture only replays a successful login).

## Checklist
- [x] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
- guardFocus's polling window/interval (2000ms / 100ms, in modalFocusContainment.ts) is a hedge against Argyle asynchronously resetting focus after invoking onClose/onError. Argyle's container is confirmed to never be removed from the DOM, so we can't key off DOM removal — polling document.activeElement for a fallback to <body> was the most reliable signal found, but the exact timing isn't fully validated against every real interaction path; worth a close look during review/live testing.
