### PR TITLE
Turn off e2e tests for now

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,8 +1,12 @@
 name: E2E Tests
 
+# Disabled: E2E tests are currently blocked by a stale/broken recording of the
+# Argyle sandbox flow (VCR cassette drift, plus an Argyle Link widget
+# token-refresh issue). Tracked in PF-801. Re-enable the CI job when issue resolved.
 on:
-  pull_request:
-    paths: ['app/**']
+  workflow_dispatch:
+  # pull_request:
+  #   paths: ['app/**']
 
 jobs:
   e2e:

--- a/app/config/initializers/session_store.rb
+++ b/app/config/initializers/session_store.rb
@@ -1,3 +1,7 @@
-Rails.application.config.session_store :cookie_store,
-  key: "_iv_cbv_payroll_session",
-  expire_after: Rails.application.config.cbv_session_expires_after
+# Skip session expiry in E2E runs
+# TODO: if we ever want e2e coverage of expiry behavior, we should revisit
+if ENV["E2E_RUN_TESTS"].nil?
+  Rails.application.config.session_store :cookie_store,
+    key: "_iv_cbv_payroll_session",
+    expire_after: Rails.application.config.cbv_session_expires_after
+end


### PR DESCRIPTION
* Add's DSAC's upstream fix for cookie store. https://github.com/DSACMS/iv-cbv-payroll/pull/1808 
* Disables E2E CI job while the VCR cassettes need to be rebuilt.