### PR TITLE
PF-789: Increase the maximum # of paystubs that can be retrieved before triggering a New Relic alert.

### DIFF
--- a/app/app/services/aggregators/aggregator_reports/argyle_report.rb
+++ b/app/app/services/aggregators/aggregator_reports/argyle_report.rb
@@ -10,13 +10,6 @@ module Aggregators::AggregatorReports
 
     DISCONNECTED_STATES = %w[disconnected]
 
-    # Upper bound on how many paystubs we expect to retrieve for a single
-    # account, expressed as a multiple of the lookback window in days. Even
-    # daily pay would not exceed one paystub per day, so 2x is a generous
-    # guardrail — exceeding it signals a data anomaly (e.g. duplicate paystubs
-    # or runaway pagination) that we want surfaced in New Relic.
-    MAX_PAYSTUBS_PER_LOOKBACK_DAY = 2
-
     validates_with Aggregators::Validators::UsefulReportValidator, on: :useful_report
 
     attr_reader :argyle_service
@@ -113,13 +106,16 @@ module Aggregators::AggregatorReports
       end
     end
 
-    # Guardrail against retrieving an anomalously large number of paystubs.
-    # The cap is the lookback window (in days) x MAX_PAYSTUBS_PER_LOOKBACK_DAY.
-    # If the retrieved count reaches the cap, we surface the error to New Relic.
-    # We are not blocked the flow, so the user can still continue and finish, but we will want to look into why this happened.
+    # Guardrail against retrieving an anomalously large number of paystubs for a
+    # single account. The cap is set high enough that legitimate gig workers
+    # with frequent cashouts should never reach it; reaching it signals a data
+    # anomaly that we want surfaced in New Relic.
+    #
+    # This is observability only — we do not raise, so the applicant can still
+    # continue and finish the flow, but we will want to look into why it happened.
     def check_paystub_volume(paystubs_json, payroll_account)
-      max_paystubs = @fetched_days.to_i * MAX_PAYSTUBS_PER_LOOKBACK_DAY
-      return if max_paystubs.zero?
+      max_paystubs = max_paystubs_per_account
+      return if max_paystubs.nil? || max_paystubs <= 0
 
       paystub_count = paystubs_json["results"].size
       return if paystub_count < max_paystubs
@@ -127,7 +123,7 @@ module Aggregators::AggregatorReports
       error = PaystubLimitExceededError.new(
         "Retrieved #{paystub_count} paystubs for account " \
         "#{payroll_account.aggregator_account_id}, reaching the max of #{max_paystubs} " \
-        "(#{@fetched_days} lookback days x #{MAX_PAYSTUBS_PER_LOOKBACK_DAY})"
+        "(#{@fetched_days} lookback days)"
       )
       Rails.logger.error(error.message)
       NewRelic::Agent.notice_error(error, custom_params: {
@@ -137,6 +133,10 @@ module Aggregators::AggregatorReports
         max_paystubs: max_paystubs,
         lookback_days: @fetched_days
       })
+    end
+
+    def max_paystubs_per_account
+      Rails.application.config.max_paystubs_per_account
     end
 
     def transform_identities(identities_json)

--- a/app/config/application.rb
+++ b/app/config/application.rb
@@ -64,6 +64,8 @@ module IvCbvPayroll
     # This is tech debt. Supported providers is a required env variable, but should be configured elsewhere.
     config.supported_providers = (ENV["SUPPORTED_PROVIDERS"] || "pinwheel")&.split(",")&.map(&:to_sym)
     config.cbv_session_expires_after = 30.minutes
+
+    config.max_paystubs_per_account = 10_000
   end
 
   def self.client_agencies

--- a/app/config/application.rb
+++ b/app/config/application.rb
@@ -65,7 +65,7 @@ module IvCbvPayroll
     config.supported_providers = (ENV["SUPPORTED_PROVIDERS"] || "pinwheel")&.split(",")&.map(&:to_sym)
     config.cbv_session_expires_after = 30.minutes
 
-    config.max_paystubs_per_account = 10_000
+    config.max_paystubs_per_account = 1000
   end
 
   def self.client_agencies

--- a/app/spec/services/aggregators/aggregator_reports/argyle_report_spec.rb
+++ b/app/spec/services/aggregators/aggregator_reports/argyle_report_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Aggregators::AggregatorReports::ArgyleReport, type: :service do
 
   describe "config.max_paystubs_per_account" do
     it "ships a deliberately high default so gig workers are not constrained" do
-      expect(Rails.application.config.max_paystubs_per_account).to eq(10_000)
+      expect(Rails.application.config.max_paystubs_per_account).to eq(1000)
     end
   end
 
@@ -94,10 +94,10 @@ RSpec.describe Aggregators::AggregatorReports::ArgyleReport, type: :service do
     end
 
     context "with the app's shipped default cap" do
-      let(:max_paystubs_per_account) { 10_000 }
+      let(:max_paystubs_per_account) { 1000 }
 
       it "does not trip for a gig worker with many frequent cashouts" do
-        report.send(:check_paystub_volume, { "results" => Array.new(2_000) { {} } }, payroll_account)
+        report.send(:check_paystub_volume, { "results" => Array.new(999) { {} } }, payroll_account)
 
         expect(NewRelic::Agent).not_to have_received(:notice_error)
       end

--- a/app/spec/services/aggregators/aggregator_reports/argyle_report_spec.rb
+++ b/app/spec/services/aggregators/aggregator_reports/argyle_report_spec.rb
@@ -30,6 +30,12 @@ RSpec.describe Aggregators::AggregatorReports::ArgyleReport, type: :service do
     Timecop.freeze(today, &ex)
   end
 
+  describe "config.max_paystubs_per_account" do
+    it "ships a deliberately high default so gig workers are not constrained" do
+      expect(Rails.application.config.max_paystubs_per_account).to eq(10_000)
+    end
+  end
+
   describe "#check_paystub_volume (anomalous-paystub-count guardrail)" do
     let(:report) do
       Aggregators::AggregatorReports::ArgyleReport.new(
@@ -40,8 +46,17 @@ RSpec.describe Aggregators::AggregatorReports::ArgyleReport, type: :service do
       )
     end
 
+    let(:max_paystubs_per_account) { 10 }
+
+    around do |ex|
+      old_value = Rails.application.config.max_paystubs_per_account
+      Rails.application.config.max_paystubs_per_account = max_paystubs_per_account
+      ex.run
+    ensure
+      Rails.application.config.max_paystubs_per_account = old_value
+    end
+
     before do
-      # cap = @fetched_days * MAX_PAYSTUBS_PER_LOOKBACK_DAY(2) = 10
       report.instance_variable_set(:@fetched_days, 5)
       allow(Rails.logger).to receive(:error)
       allow(NewRelic::Agent).to receive(:notice_error)
@@ -66,6 +81,26 @@ RSpec.describe Aggregators::AggregatorReports::ArgyleReport, type: :service do
       report.send(:check_paystub_volume, under_cap, payroll_account)
 
       expect(NewRelic::Agent).not_to have_received(:notice_error)
+    end
+
+    context "when the configured cap is disabled" do
+      let(:max_paystubs_per_account) { nil }
+
+      it "does not report regardless of the paystub count" do
+        report.send(:check_paystub_volume, { "results" => Array.new(50_000) { {} } }, payroll_account)
+
+        expect(NewRelic::Agent).not_to have_received(:notice_error)
+      end
+    end
+
+    context "with the app's shipped default cap" do
+      let(:max_paystubs_per_account) { 10_000 }
+
+      it "does not trip for a gig worker with many frequent cashouts" do
+        report.send(:check_paystub_volume, { "results" => Array.new(2_000) { {} } }, payroll_account)
+
+        expect(NewRelic::Agent).not_to have_received(:notice_error)
+      end
     end
   end
 


### PR DESCRIPTION
## Summary
PF-789: Increase the maximum # of paystubs that can be retrieved before triggering a New Relic alert.

## Type of Change
Check all that apply.
- [ ] Bug
- [x] Feature
- [ ] Refactor
- [ ] Documentation update

## Changes
[add concise bullet points of changes here]

## Checklist
- [x] Tests added/updated (if needed)
- [ ] Docs updated (if needed)

## Notes for Reviewers
[if anything need special attention, note it here]


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216769876088012