### PR TITLE
Fix Anchore/Grype Scanner

### DIFF
--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -93,22 +93,26 @@ jobs:
           echo "image=$IMAGE_NAME:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Run Grype vulnerability scan
-        uses: anchore/scan-action@v6.2.0
+        uses: anchore/scan-action@v7
         with:
           image: ${{ steps.build-image.outputs.image }}
           output-format: table
           output-file: grype-results.txt
           severity-cutoff: high
 
-      - name: Save output to workflow summary
+      - name: Save output to job log and workflow summary
         if: always() # Runs even if there is a failure
         run: |
-          cat grype-results.txt
-          {
-            echo '```'
+          if [ -s grype-results.txt ]; then
             cat grype-results.txt
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+            {
+              echo '```'
+              cat grype-results.txt
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No scan results produced (scan may have failed before generating the report)" | tee -a "$GITHUB_STEP_SUMMARY"
+          fi
 
   dockle-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -94,6 +94,8 @@ jobs:
 
       - name: Run Grype vulnerability scan
         uses: anchore/scan-action@v7
+        env:
+          GRYPE_SORT_BY: severity
         with:
           image: ${{ steps.build-image.outputs.image }}
           output-format: table

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -103,6 +103,7 @@ jobs:
       - name: Save output to workflow summary
         if: always() # Runs even if there is a failure
         run: |
+          cat grype-results.txt
           {
             echo '```'
             cat grype-results.txt

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           echo "View results in GitHub Action logs" >> "$GITHUB_STEP_SUMMARY"
 
-  anchore-scan:
+  grype-scan:
     runs-on: ubuntu-latest
 
     steps:
@@ -92,16 +92,22 @@ jobs:
           IMAGE_TAG=$(make release-image-tag)
           echo "image=$IMAGE_NAME:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
 
-      - name: Run Anchore vulnerability scan
+      - name: Run Grype vulnerability scan
         uses: anchore/scan-action@v6.2.0
         with:
           image: ${{ steps.build-image.outputs.image }}
           output-format: table
+          output-file: grype-results.txt
           severity-cutoff: high
 
       - name: Save output to workflow summary
         if: always() # Runs even if there is a failure
-        run: echo "View results in GitHub Action logs" >> "$GITHUB_STEP_SUMMARY"
+        run: |
+          {
+            echo '```'
+            cat grype-results.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
   dockle-scan:
     runs-on: ubuntu-latest

--- a/.grype.yml
+++ b/.grype.yml
@@ -1,4 +1,4 @@
-# List of vulnerabilities to ignore for the anchore scan
+# List of vulnerabilities to ignore for the Grype scan (run via anchore/scan-action)
 # https://github.com/anchore/grype#specifying-matches-to-ignore
 # More info can be found in the docs/infra/vulnerability-management.md file
 


### PR DESCRIPTION
* rename anchore-scanner to grype-scanner because anchore actually uses grype underneath after anchor was EOL'd.
* Force grype scanner to dump contents to stdout so that github CI job can actually see the found vulnerabilities.