### PR TITLE
Upgrade net-imap to 0.5.15

### DIFF
--- a/app/Gemfile
+++ b/app/Gemfile
@@ -67,7 +67,7 @@ gem "rack", "~> 3.2.6"
 # https://www.ruby-lang.org/en/news/2024/08/01/dos-rexml-cve-2024-41123/
 gem "rexml", "~> 3.4.2"
 gem "gpgme", "~> 2.0", ">= 2.0.12"
-gem "net-imap", "0.5.14"  # Fixing CVE-2026-42246 (STARTTLS stripping) + GHSA-j3g3-5qv5-52mj
+gem "net-imap", "~> 0.5.15"  # Fixing CVE-2026-42246 (STARTTLS stripping) + GHSA-j3g3-5qv5-52mj + GHSA-8p34-64r3-mwg8 + GHSA-46q3-7gv7-qmgg
 gem "cgi", ">= 0.4.2"     # Fixing GHSA-mhwm-jh88-3gjf
 gem "thor", ">= 1.4.0"    # Fixing GHSA-mqcp-p2hv-vw6x
 gem "uri", ">= 1.0.4"     # Fixing CVE-2025-61594

--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -287,7 +287,7 @@ GEM
     mutex_m (0.3.0)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.5.14)
+    net-imap (0.5.15)
       date
       net-protocol
     net-pop (0.1.2)
@@ -603,7 +603,7 @@ DEPENDENCIES
   jsbundling-rails
   mixpanel-ruby
   mutex_m
-  net-imap (= 0.5.14)
+  net-imap (~> 0.5.15)
   net-sftp
   net-ssh
   newrelic_rpm


### PR DESCRIPTION
## Stacked PR 5 of 5 (base: #601)

Switches to minimum version pin (`~> 0.5.15`) for net-imap. 

### Fixes
- **net-imap 0.5.15** — GHSA-8p34-64r3-mwg8 (Medium), GHSA-46q3-7gv7-qmgg (Medium)
 The exact `0.5.14` pin (originally added for CVE-2026-42246) was blocking the fixes for more recent vulnerabilities shipped with 0.5.15. Please see [release notes for 0.5.15 ](https://github.com/ruby/net-imap/releases/tag/v0.5.15) for changelog. 

### Verification
* Verified the release notes for 0.5.15 are primarily security & bug fixes that should not impact VMI
* Note: there are no integration tests for emails/imap.  